### PR TITLE
Cleanup errors, fix lint

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -24,7 +24,8 @@ var TypedError = require('error/typed');
 
 module.exports.InvalidTypeidError = TypedError({
     type: 'thrift-invalid-typeid',
-    message: 'invalid typeid {typeid} of {what}; expects one of the values in TYPE',
+    message: 'invalid typeid {typeid} of {what}' +
+        '; expects one of the values in TYPE',
     typeid: null,
     what: null
 });

--- a/tlist.js
+++ b/tlist.js
@@ -50,8 +50,10 @@ inherits(TListRW, bufrw.Base);
 TListRW.prototype.byteLength = function byteLength(list) {
     var etype = this.ttypes[list.etypeid];
     if (!etype) {
-        return LengthResult.error(
-            InvalidTypeidError({typeid: list.etypeid, what: 'list::etype'}));
+        return LengthResult.error(InvalidTypeidError({
+            typeid: list.etypeid,
+            what: 'list::etype'
+        }));
     }
 
     var length = 5; // header length
@@ -69,8 +71,10 @@ TListRW.prototype.byteLength = function byteLength(list) {
 TListRW.prototype.writeInto = function writeInto(list, buffer, offset) {
     var etype = this.ttypes[list.etypeid];
     if (!etype) {
-        return WriteResult.error(
-            InvalidTypeidError({typeid: list.etypeid, what: 'list::etype'}));
+        return WriteResult.error(InvalidTypeidError({
+            typeid: list.etypeid,
+            what: 'list::etype'
+        }));
     }
 
     var t = this.headerRW.writeInto([list.etypeid, list.elements.length],
@@ -99,13 +103,19 @@ TListRW.prototype.readFrom = function readFrom(buffer, offset) {
     var etypeid = t.value[0];
     var size = t.value[1];
     if (size < 0) {
-        return ReadResult.error(InvalidSizeError({size: size, what: 'list::size'}));
+        return ReadResult.error(InvalidSizeError({
+            size: size,
+            what: 'list::size'
+        }));
     }
 
     var list = new TList(etypeid);
     var etype = this.ttypes[list.etypeid];
     if (!etype) {
-        return ReadResult.error(InvalidTypeidError({typeid: list.etypeid, what: 'list::etype'}));
+        return ReadResult.error(InvalidTypeidError({
+            typeid: list.etypeid,
+            what: 'list::etype'
+        }));
     }
 
     for (var i = 0; i < size; i++) {

--- a/tmap.js
+++ b/tmap.js
@@ -135,7 +135,10 @@ TMapRW.prototype.readFrom = function readFrom(buffer, offset) {
     var vtypeid = t.value[1];
     var size = t.value[2];
     if (size < 0) {
-        return ReadResult.error(InvalidSizeError({size: size, what: 'map::size'}));
+        return ReadResult.error(InvalidSizeError({
+            size: size,
+            what: 'map::size'
+        }));
     }
 
     var map = new TMap(ktypeid, vtypeid);

--- a/tstruct.js
+++ b/tstruct.js
@@ -83,7 +83,7 @@ TStructRW.prototype.writeInto = function writeInto(struct, buffer, offset) {
         var field = struct.fields[i];
         var type = this.ttypes[field.typeid];
         if (!type) {
-            return LengthResult.error(InvalidTypeidError({
+            return WriteResult.error(InvalidTypeidError({
                 typeid: field.typeid, what: 'field::type'
             }));
         }
@@ -130,8 +130,9 @@ TStructRW.prototype.readFrom = function readFrom(buffer, offset) {
         }
         var type = this.ttypes[typeid];
         if (!type) {
-            return LengthResult.error(InvalidTypeidError({
-                typeid: typeid, what: 'field::type'
+            return ReadResult.error(InvalidTypeidError({
+                typeid: typeid,
+                what: 'field::type'
             }));
         }
 


### PR DESCRIPTION
- fixes lint
- correct Result type in a few places
- object literals are better of spanning lines

cc @kriskowal @leizha 