### PR TITLE
WIP: Add specializ(ed/able) RWs

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,9 @@
+- [ ] borg semantic type system from thriftify
+- [ ] borg grammar from thriftify
+- [ ] drop all type-mockes in tests to use actual type system (be more
+  "integrate"-y)
+- [ ] use type system to skip unknown fields
+- [ ] extend to support stream<T>
+  - [ ] grammar support
+  - [ ] struct or struct-like support
+  - [ ] type system support

--- a/index.js
+++ b/index.js
@@ -56,3 +56,5 @@ module.exports.BooleanRW = require('./boolean').BooleanRW;
 module.exports.SpecListRW = require('./speclist').SpecListRW;
 module.exports.SpecMapObjRW = require('./specmap-obj').SpecMapObjRW;
 module.exports.SpecMapEntriesRW = require('./specmap-entries').SpecMapEntriesRW;
+
+module.exports.SpecFieldsRWBase = require('./specfields').SpecFieldsRWBase;

--- a/index.js
+++ b/index.js
@@ -59,3 +59,4 @@ module.exports.SpecMapEntriesRW = require('./specmap-entries').SpecMapEntriesRW;
 
 module.exports.SpecFieldsRWBase = require('./specfields').SpecFieldsRWBase;
 module.exports.SpecStructRW = require('./specstruct').SpecStructRW;
+module.exports.SpecUnionRW = require('./specunion').SpecUnionRW;

--- a/index.js
+++ b/index.js
@@ -58,3 +58,4 @@ module.exports.SpecMapObjRW = require('./specmap-obj').SpecMapObjRW;
 module.exports.SpecMapEntriesRW = require('./specmap-entries').SpecMapEntriesRW;
 
 module.exports.SpecFieldsRWBase = require('./specfields').SpecFieldsRWBase;
+module.exports.SpecStructRW = require('./specstruct').SpecStructRW;

--- a/specfields.js
+++ b/specfields.js
@@ -1,0 +1,163 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var bufrw = require('bufrw');
+var util = require('util');
+var TYPE = require('./TYPE');
+var inherits = require('util').inherits;
+
+var LengthResult = bufrw.LengthResult;
+var ReadResult = bufrw.ReadResult;
+
+// field :: {name, id, type}
+// type :: {name, typeid, rw}
+
+function SpecFieldsRWBase(fields) {
+    var self = this;
+    self.fields = fields || [];
+    self.fieldById = {};
+    self.fieldByName = {};
+    self.allFixed = true;
+    self.fixedWidth = 0;
+    self.fields.forEach(function each(field) {
+        self.fieldById[field.id] = field;
+        self.fieldByName[field.name] = field;
+        self.allFixed = self.allFixed && field.type.rw.width;
+        if (field.type.rw.width) {
+            self.fixedWidth += 3 + field.type.rw.width; // type:1 id:2 ...
+        }
+    });
+}
+inherits(SpecFieldsRWBase, bufrw.Base);
+
+SpecFieldsRWBase.prototype.fieldByteLength =
+function fieldByteLength(field, value) {
+    if (field.type.rw.width) {
+        return LengthResult.just(3 + field.type.rw.width);
+    } else {
+        var res = field.type.rw.byteLength(value);
+        if (!res.err) {
+            res.length += 3; // type:1 id:2 ...
+        }
+        return res;
+    }
+};
+
+SpecFieldsRWBase.prototype.writeFieldInto =
+function writeFieldInto(field, value, buffer, offset) {
+    // type:1
+    var res = bufrw.Int8.writeInto(field.type.typeid, buffer, offset);
+    if (res.err) {
+        return res;
+    }
+    offset = res.offset;
+
+    // id:2
+    res = bufrw.Int16BE.writeInto(field.id, buffer, offset);
+    if (res.err) {
+        return res;
+    }
+    offset = res.offset;
+
+    // ...
+    res = field.type.rw.writeInto(value, buffer, offset);
+    if (res.err) {
+        return res;
+    }
+    offset = res.offset;
+
+    return res;
+};
+
+SpecFieldsRWBase.prototype.readAnyFieldFrom =
+function readAnyFieldFrom(buffer, offset) {
+    /* eslint max-statements:[0, 99] */
+    var self = this;
+
+    // type:1
+    var res = bufrw.Int8.readFrom(buffer, offset);
+    if (res.err) {
+        return res;
+    }
+    offset = res.offset;
+    var typeid = res.value;
+
+    if (typeid === TYPE.STOP) {
+        res.value = new StopResult();
+        return res;
+    }
+
+    // id:2
+    res = bufrw.Int16BE.readFrom(buffer, offset);
+    if (res.err) {
+        return res;
+    }
+    offset = res.offset;
+    var id = res.value;
+
+    var field = self.fieldById[id];
+    if (!field) {
+        res.value = new UnknownResult();
+        return res;
+    }
+
+    if (typeid !== field.type.typeid) {
+        // TODO: typed error
+        return ReadResult.error(new Error(util.format(
+            'mismatched field type %s, expected %s for field %s',
+            typeid, field.type.typeid, id)), offset);
+    }
+
+    // ...
+    res = field.type.rw.readFrom(buffer, offset);
+    if (res.err) {
+        return res;
+    }
+    offset = res.offset;
+
+    res.value = new FieldValueResult(field, res.value);
+
+    return res;
+};
+
+module.exports.SpecFieldsRWBase = SpecFieldsRWBase;
+
+function StopResult() {
+    this.field = null;
+    this.value = null;
+    this.stop = true;
+    this.unknown = false;
+}
+
+function UnknownResult() {
+    this.field = null;
+    this.value = null;
+    this.stop = false;
+    this.unknown = true;
+}
+
+function FieldValueResult(field, value) {
+    this.field = field;
+    this.value = value;
+    this.stop = false;
+    this.unknown = false;
+}

--- a/specstruct.js
+++ b/specstruct.js
@@ -52,6 +52,13 @@ inherits(SpecStructRW, SpecFieldsRWBase);
 
 SpecStructRW.prototype.byteLength = function byteLength(struct) {
     var self = this;
+    if (!(struct instanceof self.cons)) {
+        // TODO: typed error
+        return LengthResult.error(new Error(util.format(
+            'invalid struct value, expected instance of %s',
+            self.cons.name)));
+    }
+
     var length = 1; // STOP byte
     for (var i = 0; i < self.fields.length; i++) {
         var field = self.fields[i];
@@ -66,18 +73,32 @@ SpecStructRW.prototype.byteLength = function byteLength(struct) {
 
 SpecStructRW.prototype.fixedByteLength = function fixedByteLength(struct) {
     var self = this;
+    if (!(struct instanceof self.cons)) {
+        // TODO: typed error
+        return LengthResult.error(new Error(util.format(
+            'invalid struct value, expected instance of %s',
+            self.cons.name)));
+    }
+
     return LengthResult.just(self.fixedWidth);
 };
 
 SpecStructRW.prototype.writeInto = function writeInto(struct, buffer, offset) {
     var self = this;
     var res = null;
+    if (!(struct instanceof self.cons)) {
+        // TODO: typed error
+        return WriteResult.error(new Error(util.format(
+            'invalid struct value, expected instance of %s',
+            self.cons.name)));
+    }
 
     // TODO: support optional fields
     for (var i = 0; i < self.fields.length; i++) {
         var field = self.fields[i];
         var value = struct[field.name];
-        // TODO: error if value is undefined?
+        // TODO
+        // if (value === undefined) { }
         res = self.writeFieldInto(field, value, buffer, offset);
         // istanbul ignore if
         if (res.err) return res;
@@ -111,6 +132,7 @@ SpecStructRW.prototype.readFrom = function readFrom(buffer, offset) {
         // if (fieldValue.unknown) continue;
         struct[fieldValue.field.name] = fieldValue.value;
     }
+
     return ReadResult.just(offset, struct);
 };
 

--- a/specstruct.js
+++ b/specstruct.js
@@ -1,0 +1,142 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+/* eslint max-statements:[0, 99] */
+
+var bufrw = require('bufrw');
+var TYPE = require('./TYPE');
+var util = require('util');
+var inherits = util.inherits;
+
+var LengthResult = bufrw.LengthResult;
+var WriteResult = bufrw.WriteResult;
+var ReadResult = bufrw.ReadResult;
+
+var SpecFieldsRWBase = require('./specfields').SpecFieldsRWBase;
+
+function SpecStructRW(cons, fields) {
+    var self = this;
+    SpecFieldsRWBase.call(self, fields);
+    if (self.allFixed) {
+        self.fixedWidth += 1; // all fixed fields + STOP byte
+        self.byteLength = self.fixedByteLength;
+    }
+
+    // istanbul ignore if TODO
+    if (typeof cons === 'function') {
+        self.cons = cons;
+    } else {
+        self.cons = createConstructor(cons, self.fields);
+    }
+}
+inherits(SpecStructRW, SpecFieldsRWBase);
+
+SpecStructRW.prototype.byteLength = function byteLength(struct) {
+    var self = this;
+    var length = 1; // STOP byte
+    for (var i = 0; i < self.fields.length; i++) {
+        var field = self.fields[i];
+        var value = struct[field.name];
+        var res = self.fieldByteLength(field, value);
+        // istanbul ignore if
+        if (res.err) return res;
+        length += res.length;
+    }
+    return LengthResult.just(length);
+};
+
+SpecStructRW.prototype.fixedByteLength = function fixedByteLength(struct) {
+    var self = this;
+    return LengthResult.just(self.fixedWidth);
+};
+
+SpecStructRW.prototype.writeInto = function writeInto(struct, buffer, offset) {
+    var self = this;
+    var res = null;
+
+    // TODO: support optional fields
+    for (var i = 0; i < self.fields.length; i++) {
+        var field = self.fields[i];
+        var value = struct[field.name];
+        // TODO: error if value is undefined?
+        res = self.writeFieldInto(field, value, buffer, offset);
+        // istanbul ignore if
+        if (res.err) return res;
+        offset = res.offset;
+    }
+
+    // stop byte
+    res = bufrw.Int8.writeInto(TYPE.STOP, buffer, offset);
+    // istanbul ignore if
+    if (res.err) return res;
+    offset = res.offset;
+
+    return WriteResult.just(offset);
+};
+
+SpecStructRW.prototype.readFrom = function readFrom(buffer, offset) {
+    /* eslint no-constant-condition:[0] new-cap:[0] */
+    var self = this;
+    var struct = new self.cons();
+
+    // TODO: support required fields
+    while (true) {
+        var res = self.readAnyFieldFrom(buffer, offset);
+        // istanbul ignore if
+        if (res.err) return res;
+        offset = res.offset;
+        var fieldValue = res.value;
+        if (fieldValue.stop) break;
+
+        // TODO: handle unknown fields
+        // if (fieldValue.unknown) continue;
+        struct[fieldValue.field.name] = fieldValue.value;
+    }
+    return ReadResult.just(offset, struct);
+};
+
+module.exports.SpecStructRW = SpecStructRW;
+
+function createConstructor(name, fields) {
+    var consName = 'Thriftify_' + name.replace(/[^0-9A-Za-z_$]+/g, '_');
+    var source = '(function ' + consName + '() {\n';
+    for (var i = 0; i < fields.length; i++) {
+        name = fields[i].name;
+        source += '    this';
+        // istanbul ignore else TODO
+        if (/^[A-Za-z_$][0-9A-Za-z_$]*$/.test(name)) {
+            source += '.' + name;
+        } else {
+            source += '["' + name + '"]';
+        }
+        // TODO: use type-specific zero
+        source += ' = null;\n';
+    }
+    source += '})\n';
+    // eval is an operator that captures the lexical scope of the calling
+    // function and deoptimizes the lexical scope. By using eval in an
+    // expression context, it loses this second-class capability and becomes a
+    // first-class function. (0, eval) is one way to use eval in an expression
+    // context.
+    /* jshint -W067:true */
+    return (0, eval)(source);
+}

--- a/specunion.js
+++ b/specunion.js
@@ -1,0 +1,131 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+/* eslint max-statements:[0, 99] */
+
+var bufrw = require('bufrw');
+var util = require('util');
+var TYPE = require('./TYPE');
+var inherits = require('util').inherits;
+
+var LengthResult = bufrw.LengthResult;
+var WriteResult = bufrw.WriteResult;
+var ReadResult = bufrw.ReadResult;
+
+var SpecFieldsRWBase = require('./specfields').SpecFieldsRWBase;
+
+// TODO: could share a base class with SpecStructRW, something like FieldSpecRW
+
+function SpecUnionRW(fields) {
+    var self = this;
+    SpecFieldsRWBase.call(self, fields);
+}
+inherits(SpecUnionRW, SpecFieldsRWBase);
+
+SpecUnionRW.prototype.byteLength = function byteLength(pair) {
+    var self = this;
+    var name = pair[0];
+    var value = pair[1];
+    var field = self.fieldByName[name];
+    if (!field) {
+        // TODO typed error
+        return LengthResult.error(new Error(util.format(
+            'invalid union type choice %s',
+            name)));
+    }
+    var length = 1; // STOP byte
+    var res = self.fieldByteLength(field, value);
+    // istanbul ignore if
+    if (res.err) return res;
+    length += res.length; // type:1 id:2 ...
+    return LengthResult.just(length);
+};
+
+SpecUnionRW.prototype.writeInto = function writeInto(pair, buffer, offset) {
+    var self = this;
+    var name = pair[0];
+    var value = pair[1];
+    var field = self.fieldByName[name];
+    if (!field) {
+        // TODO typed error
+        return WriteResult.error(new Error(util.format(
+            'invalid union type choice %s',
+            name)));
+    }
+
+    // type:1 id:2 ...
+    var res = self.writeFieldInto(field, value, buffer, offset);
+    // istanbul ignore if
+    if (res.err) return res;
+    offset = res.offset;
+
+    // stop byte
+    res = bufrw.Int8.writeInto(TYPE.STOP, buffer, offset);
+    // istanbul ignore if
+    if (res.err) return res;
+    offset = res.offset;
+
+    return WriteResult.just(offset);
+};
+
+SpecUnionRW.prototype.readFrom = function readFrom(buffer, offset) {
+    var self = this;
+
+    // type:1 id:2 ...
+    var res = self.readAnyFieldFrom(buffer, offset);
+    // istanbul ignore if
+    if (res.err) return res;
+    offset = res.offset;
+    var fieldValue = res.value;
+
+    // TODO: support nullable / optional?
+    if (fieldValue.stop) {
+        // TODO: typed error
+        return ReadResult.error(new Error('no data for union'));
+    }
+
+    // TODO: error on unknown field once SpecFieldsRWBase supports it
+    // if (fieldValue.unknown)
+
+    var pair = [fieldValue.field.name, fieldValue.value];
+
+    // stop byte
+    res = self.readAnyFieldFrom(buffer, offset);
+    // istanbul ignore if
+    if (res.err) return res;
+    offset = res.offset;
+    fieldValue = res.value;
+
+    if (!fieldValue.stop) {
+        // TODO: support unknown field once SpecFieldsRWBase implements
+        // TODO: typed error
+        return ReadResult.error(new Error(util.format(
+            'expected stop byte, found field %s(%s) instead',
+            fieldValue.field.name,
+            fieldValue.field.id
+        )), offset);
+    }
+
+    return ReadResult.just(offset, pair);
+};
+
+module.exports.SpecUnionRW = SpecUnionRW;

--- a/test/index.js
+++ b/test/index.js
@@ -28,3 +28,4 @@ require('./speclist');
 require('./specmap-obj');
 require('./specmap-entries');
 require('./specstruct');
+require('./specunion');

--- a/test/index.js
+++ b/test/index.js
@@ -27,3 +27,4 @@ require('./boolean');
 require('./speclist');
 require('./specmap-obj');
 require('./specmap-entries');
+require('./specstruct');

--- a/test/specstruct.js
+++ b/test/specstruct.js
@@ -67,6 +67,26 @@ test('SpecStructRW: emptyRW', testRW.cases(emptyRW, [
         ]
     ],
 
+    // length/write only expected object
+    {
+        lengthTest: {
+            value: {},
+            error: {
+                message: 'invalid struct value, ' +
+                         'expected instance of Thriftify_Empty'
+            }
+        },
+        writeTest: {
+            bytes: [0x00],
+            value: {},
+            error: {
+                message: 'invalid struct value, ' +
+                         'expected instance of Thriftify_Empty',
+                offset: 0
+            }
+        }
+    },
+
     // unknown field
     {
         readTest: {
@@ -105,6 +125,17 @@ test('SpecStructRW: personRW', testRW.cases(personRW, [
             0x00              // type:1    -- STOP
         ]
     ],
+
+    // length only expected object (needed for coverage vs the empty case)
+    {
+        lengthTest: {
+            value: {},
+            error: {
+                message: 'invalid struct value, ' +
+                         'expected instance of Thriftify_Person'
+            }
+        }
+    },
 
     // mismatched typeid
     {

--- a/test/specstruct.js
+++ b/test/specstruct.js
@@ -1,0 +1,161 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/* eslint new-cap:0 */
+
+'use strict';
+
+var test = require('tape');
+var bufrw = require('bufrw');
+var testRW = require('bufrw/test_rw');
+
+var thriftrw = require('../index');
+var SpecStructRW = thriftrw.SpecStructRW;
+
+var strType = {
+    name: 'string',
+    typeid: 1,
+    rw: bufrw.str1
+};
+
+var i16Type = {
+    name: 'i16',
+    typeid: 2,
+    rw: bufrw.Int16BE
+};
+
+var doubleType = {
+    name: 'double',
+    typeid: 3,
+    rw: bufrw.DoubleBE
+};
+
+var emptyRW = new SpecStructRW('Empty');
+
+var personRW = new SpecStructRW('Person', [
+    {name: 'firstName', id: 1, type: strType},
+    {name: 'lastName', id: 2, type: strType},
+    {name: 'age', id: 3, type: i16Type}
+]);
+
+var testPerson = new personRW.cons();
+testPerson.firstName = 'bob';
+testPerson.lastName = 'lob';
+testPerson.age = 12;
+
+test('SpecStructRW: emptyRW', testRW.cases(emptyRW, [
+    [
+        new emptyRW.cons(), [
+            0x00              // type:1    -- STOP
+        ]
+    ],
+
+    // unknown field
+    {
+        readTest: {
+            bytes: [
+                0x02,       // type:1  -- 2
+                0x00, 0x04, // id:2    -- 3
+                0x00, 0x00, // Int16BE -- 12
+                            //         --
+                0x00        // type:1  -- STOP
+            ],
+            error: {
+                message: 'unknown field id 4 (typeid 2)',
+                offset: 0
+            }
+        }
+    }
+]));
+
+test('SpecStructRW: personRW', testRW.cases(personRW, [
+    [
+        testPerson, [
+            0x01,             // type:1    -- 1
+            0x00, 0x01,       // id:2      -- 1
+            0x03,             // str_len:1 -- 3
+            0x62, 0x6f, 0x62, // chars     -- "bob"
+                              //           --
+            0x01,             // type:1    -- 1
+            0x00, 0x02,       // id:2      -- 2
+            0x03,             // str_len:1 -- 3
+            0x6c, 0x6f, 0x62, // chars     -- "lob"
+                              //           --
+            0x02,             // type:1    -- 2
+            0x00, 0x03,       // id:2      -- 3
+            0x00, 0x0c,       // Int16BE   -- 12
+                              //           --
+            0x00              // type:1    -- STOP
+        ]
+    ],
+
+    // mismatched typeid
+    {
+        readTest: {
+            bytes: [
+                0x01,             // type:1    -- 1
+                0x00, 0x01,       // id:2      -- 1
+                0x03,             // str_len:1 -- 3
+                0x62, 0x6f, 0x62, // chars     -- "bob"
+                                  //           --
+                0x02,             // type:1    -- 1
+                0x00, 0x02,       // id:2      -- 2
+                0x03,             // str_len:1 -- 3
+                0x6c, 0x6f, 0x62, // chars     -- "lob"
+                                  //           --
+                0x02,             // type:1    -- 2
+                0x00, 0x03,       // id:2      -- 3
+                0x00, 0x0c,       // Int16BE   -- 12
+                                  //           --
+                0x00              // type:1    -- STOP
+            ],
+            error: {
+                message: 'mismatched field type 2, expected 1 for field 2',
+                offset: 10
+            }
+        }
+    }
+]));
+
+var pointRW = new SpecStructRW('Point', [
+    {name: 'lat', id: 1, type: doubleType},
+    {name: 'lng', id: 2, type: doubleType}
+]);
+var testPoint = new pointRW.cons();
+testPoint.lat = 37.787536;
+testPoint.lng = -122.403146;
+
+test('SpecStructRW: pointRW', testRW.cases(pointRW, [
+    [
+        testPoint, [
+            0x03,                   // type:1   -- 1
+            0x00, 0x01,             // id:2     -- 1
+            0x40, 0x42, 0xe4, 0xcd, // DoubleBE -- 37.787536
+            0xfa, 0xca, 0x36, 0x1a, // ...      --
+                                    //          --
+            0x03,                   // type:1   -- 1
+            0x00, 0x02,             // id:2     -- 1
+            0xc0, 0x5e, 0x99, 0xcd, // DoubleBE -- -122.403146
+            0x24, 0xe1, 0x60, 0xd9, // ...      --
+                                    //          --
+            0x00                    // type:1   -- STOP
+        ]
+    ]
+]));

--- a/test/specunion.js
+++ b/test/specunion.js
@@ -1,0 +1,116 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/* eslint new-cap:0 */
+
+'use strict';
+
+var test = require('tape');
+var bufrw = require('bufrw');
+var testRW = require('bufrw/test_rw');
+
+var thriftrw = require('../index');
+var SpecUnionRW = thriftrw.SpecUnionRW;
+
+var strType = {
+    name: 'string',
+    typeid: 1,
+    rw: bufrw.str1
+};
+
+var i16Type = {
+    name: 'i16',
+    typeid: 2,
+    rw: bufrw.Int16BE
+};
+
+var idOrUUID = new SpecUnionRW([
+    {name: 'id', id: 1, type: i16Type},
+    {name: 'uuid', id: 2, type: strType}
+]);
+
+test('SpecUnionRW: idOrUUID', testRW.cases(idOrUUID, [
+    [
+        ['id', 3], [
+            0x02,       // type:1  -- 2
+            0x00, 0x01, // id:2    -- 1
+            0x00, 0x03, // Int16BE -- 3
+            0x00        // type:2  -- STOP
+        ]
+    ],
+
+    [
+        ['uuid', '1-2-3'], [
+            0x01,                   // type:1    -- 1
+            0x00, 0x02,             // id:2      -- 2
+            0x05,                   // str_len:1 -- 5
+            0x31, 0x2d, 0x32, 0x2d, // chars     -- "1-2-"
+            0x33,                   // chars     -- "3"
+            0x00                    // type:2    -- STOP
+        ]
+    ],
+
+    // read error: more than one choice
+    {
+        readTest: {
+            bytes: [
+                0x02,                   // type:1    -- 2
+                0x00, 0x01,             // id:2      -- 1
+                0x00, 0x03,             // Int16BE   -- 3
+                0x01,                   // type:1    -- 1
+                0x00, 0x02,             // id:2      -- 2
+                0x05,                   // str_len:1 -- 5
+                0x31, 0x2d, 0x32, 0x2d, // chars     -- "1-2-"
+                0x33,                   // chars     -- "3"
+                0x00                    // type:2    -- STOP
+            ],
+            error: {
+                message: 'expected stop byte, found field uuid(2) instead',
+                offset: 14
+            }
+        }
+    },
+
+    // read empty
+    {
+        readTest: {
+            bytes: [0x00],
+            error: {
+                message: 'no data for union'
+            }
+        }
+    },
+
+    // length/write invalid choice
+    {
+        lengthTest: {
+            value: ['nope', null],
+            error: {
+                message: 'invalid union type choice nope'
+            }
+        },
+        writeTest: {
+            value: ['nope', null],
+            error: {
+                message: 'invalid union type choice nope'
+            }
+        }
+    }
+]));


### PR DESCRIPTION
## This PR is not to be merged, it tracks each of the components as I test and merge them separately:

- [x] boolean semantics on a unsigned byte
- [x] statically typed list (with fixed width optimization)
- [ ] statically typed map (with kay/val fixed width optimizations)
  - [x] as Object
  - [x] as Entries
  - [ ] as Map
- [ ] statically typed struct
- [ ] statically typed union

cc @kriskowal @leizha 