### PR TITLE
Add speclist

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -22,17 +22,26 @@
 
 var TypedError = require('error/typed');
 
-module.exports.InvalidTypeidError = TypedError({
-    type: 'thrift-invalid-typeid',
-    message: 'invalid typeid {typeid} of {what}' +
-        '; expects one of the values in TYPE',
-    typeid: null,
-    what: null
+module.exports.ListTypeIdMismatch = TypedError({
+    type: 'thrift-list-typeid-mismatch',
+    message: 'encoded typeid {encoded} doesn\'t match ' +
+        'expected type "{expected}" (id: expectedId)',
+    encoded: null,
+    expected: null,
+    expectedId: null
 });
 
 module.exports.InvalidSizeError = TypedError({
     type: 'thrift-invalid-size',
     message: 'invalid size {size} of {what}; expects non-negative number',
     size: null,
+    what: null
+});
+
+module.exports.InvalidTypeidError = TypedError({
+    type: 'thrift-invalid-typeid',
+    message: 'invalid typeid {typeid} of {what}' +
+        '; expects one of the values in TYPE',
+    typeid: null,
     what: null
 });

--- a/index.js
+++ b/index.js
@@ -53,3 +53,4 @@ module.exports.TStruct = tstruct.TStruct;
 module.exports.TStructRW = ttypes[TYPE.STRUCT];
 
 module.exports.BooleanRW = require('./boolean').BooleanRW;
+module.exports.SpecListRW = require('./speclist').SpecListRW;

--- a/speclist.js
+++ b/speclist.js
@@ -1,0 +1,138 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/* eslint max-statements:[0, 99] */
+'use strict';
+
+var bufrw = require('bufrw');
+var inherits = require('util').inherits;
+var errors = require('./errors');
+
+var LengthResult = bufrw.LengthResult;
+var ReadResult = bufrw.ReadResult;
+
+// type:1 length:4 (el...){length}
+
+function SpecListRW(type) {
+    var self = this;
+    self.type = type;
+
+    if (self.type.rw.width) {
+        self.byteLength = self.listFixByteLength;
+    }
+}
+inherits(SpecListRW, bufrw.Base);
+
+SpecListRW.prototype.byteLength = function listVarByteLength(list) {
+    var self = this;
+    var len = 5; // type:1 length:4
+    for (var i = 0; i < list.length; i++) {
+        var res = self.type.rw.byteLength(list[i]);
+        // istanbul ignore if
+        if (res.err) {
+            return res;
+        }
+        len += res.length;
+    }
+    return LengthResult.just(len);
+};
+
+SpecListRW.prototype.listFixByteLength = function listFixByteLength(list) {
+    var self = this;
+    var len = 5 + list.length * self.type.rw.width;
+    return LengthResult.just(len);
+};
+
+SpecListRW.prototype.writeInto = function writeInto(list, buffer, offset) {
+    var self = this;
+
+    // type:1
+    var res = bufrw.UInt8.writeInto(self.type.typeid, buffer, offset);
+    // istanbul ignore if
+    if (res.err) {
+        return res;
+    }
+    offset = res.offset;
+
+    // length:4
+    res = bufrw.UInt32BE.writeInto(list.length, buffer, offset);
+    // istanbul ignore if
+    if (res.err) {
+        return res;
+    }
+
+    // (...){length}
+    for (var i = 0; i < list.length; i++) {
+        offset = res.offset;
+        res = self.type.rw.writeInto(list[i], buffer, offset);
+        // istanbul ignore if
+        if (res.err) {
+            return res;
+        }
+    }
+
+    return res;
+};
+
+SpecListRW.prototype.readFrom = function readFrom(buffer, offset) {
+    var self = this;
+
+    // type:1
+    var res = bufrw.UInt8.readFrom(buffer, offset);
+    // istanbul ignore if
+    if (res.err) {
+        return res;
+    }
+    offset = res.offset;
+    var typeid = res.value;
+
+    if (typeid !== self.type.typeid) {
+        return ReadResult.error(errors.ListTypeIdMismatch({
+            encoded: typeid,
+            expected: self.type.name,
+            expectedId: self.type.typeid
+        }), offset);
+    }
+
+    // length:4
+    res = bufrw.UInt32BE.readFrom(buffer, offset);
+    // istanbul ignore if
+    if (res.err) {
+        return res;
+    }
+    var length = res.value;
+
+    // (...){length}
+    var list = [];
+    for (var i = 0; i < length; i++) {
+        offset = res.offset;
+        res = self.type.rw.readFrom(buffer, offset);
+        // istanbul ignore if
+        if (res.err) {
+            return res;
+        }
+        list.push(res.value);
+    }
+
+    res.value = list;
+    return res;
+};
+
+module.exports.SpecListRW = SpecListRW;

--- a/test/index.js
+++ b/test/index.js
@@ -24,3 +24,4 @@ require('./tlist');
 require('./tmap');
 require('./tstruct');
 require('./boolean');
+require('./speclist');

--- a/test/speclist.js
+++ b/test/speclist.js
@@ -1,0 +1,91 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var test = require('tape');
+var bufrw = require('bufrw');
+var testRW = require('bufrw/test_rw');
+
+var thriftrw = require('../index');
+var SpecListRW = thriftrw.SpecListRW;
+
+var byteListRW = new SpecListRW({
+    name: 'byte',
+    typeid: 42,
+    rw: bufrw.UInt8
+});
+var strListRW = new SpecListRW({
+    name: 'string',
+    typeid: 99,
+    rw: bufrw.str1
+});
+
+test('SpecListRW: byteListRW', testRW.cases(byteListRW, [
+
+    [[], [
+        0x2a,                  // type:1   -- 42
+        0x00, 0x00, 0x00, 0x00 // length:4 -- 0
+    ]],
+
+    [[1, 2, 3], [
+        0x2a,                   // type:1   -- 42
+        0x00, 0x00, 0x00, 0x03, // length:4 -- 3
+        0x01,                   // UInt8    -- 1
+        0x02,                   // UInt8    -- 2
+        0x03                    // UInt8    -- 3
+    ]],
+
+    {
+        readTest: {
+            bytes: [
+                0x2b,                  // type:1   -- 42
+                0x00, 0x00, 0x00, 0x00 // length:4 -- 0
+            ],
+            error: {
+                type: 'thrift-list-typeid-mismatch',
+                name: 'ThriftListTypeidMismatchError',
+                message: 'encoded typeid 43 doesn\'t match expected ' +
+                         'type "byte" (id: expectedId)'
+            }
+        }
+    }
+
+]));
+
+test('SpecListRW: strListRW', testRW.cases(strListRW, [
+
+    [[], [
+        0x63,                  // type:1   -- 42
+        0x00, 0x00, 0x00, 0x00 // length:4 -- 0
+    ]],
+
+    [['a', 'ab', 'abc'], [
+        0x63,                   // type:1    -- 42
+        0x00, 0x00, 0x00, 0x03, // length:4  -- 3
+        0x01,                   // str_len:1 -- 1
+        0x61,                   // chars     -- "a"
+        0x02,                   // str_len:1 -- 1
+        0x61, 0x62,             // chars     -- "ab"
+        0x03,                   // str_len:1 -- 1
+        0x61, 0x62, 0x63        // chars     -- "abc"
+    ]]
+
+]));


### PR DESCRIPTION
Continuing decomposition of #3:
- pivoted api to be `SpecListRW(type :: {name, typeid, rw})`
- implemented typed error
- "100%" test coverage

r @Raynos @kriskowal 