### PR TITLE
Assimilate Thrift IDL parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   ],
   "dependencies": {
     "bufrw": "^0.9.4",
-    "error": "^5.1.1"
+    "error": "^5.1.1",
+    "pegjs": "^0.8.0"
   },
   "devDependencies": {
     "coveralls": "^2.10.0",

--- a/test/JavaBeansTest.json
+++ b/test/JavaBeansTest.json
@@ -1,0 +1,179 @@
+{
+  "type": "Program",
+  "headers": [
+    {
+      "id": {
+        "name": "thrift.test"
+      },
+      "scope": "java"
+    }
+  ],
+  "definitions": [
+    {
+      "id": {
+        "name": "OneOfEachBeans"
+      },
+      "fields": [
+        {
+          "id": {
+            "name": "boolean_field"
+          },
+          "fieldType": {
+            "primitiveType": "bool",
+            "annotations": null
+          },
+          "fid": 1,
+          "req": null
+        },
+        {
+          "id": {
+            "name": "a_bite"
+          },
+          "fieldType": {
+            "primitiveType": "byte",
+            "annotations": null
+          },
+          "fid": 2,
+          "req": null
+        },
+        {
+          "id": {
+            "name": "integer16"
+          },
+          "fieldType": {
+            "primitiveType": "i16",
+            "annotations": null
+          },
+          "fid": 3,
+          "req": null
+        },
+        {
+          "id": {
+            "name": "integer32"
+          },
+          "fieldType": {
+            "primitiveType": "i32",
+            "annotations": null
+          },
+          "fid": 4,
+          "req": null
+        },
+        {
+          "id": {
+            "name": "integer64"
+          },
+          "fieldType": {
+            "primitiveType": "i64",
+            "annotations": null
+          },
+          "fid": 5,
+          "req": null
+        },
+        {
+          "id": {
+            "name": "double_precision"
+          },
+          "fieldType": {
+            "primitiveType": "double",
+            "annotations": null
+          },
+          "fid": 6,
+          "req": null
+        },
+        {
+          "id": {
+            "name": "some_characters"
+          },
+          "fieldType": {
+            "primitiveType": "string",
+            "annotations": null
+          },
+          "fid": 7,
+          "req": null
+        },
+        {
+          "id": {
+            "name": "base64"
+          },
+          "fieldType": {
+            "primitiveType": "binary",
+            "annotations": null
+          },
+          "fid": 8,
+          "req": null
+        },
+        {
+          "id": {
+            "name": "byte_list"
+          },
+          "fieldType": {
+            "fieldType": {
+              "primitiveType": "byte",
+              "annotations": null
+            }
+          },
+          "fid": 9,
+          "req": null
+        },
+        {
+          "id": {
+            "name": "i16_list"
+          },
+          "fieldType": {
+            "fieldType": {
+              "primitiveType": "i16",
+              "annotations": null
+            }
+          },
+          "fid": 10,
+          "req": null
+        },
+        {
+          "id": {
+            "name": "i64_list"
+          },
+          "fieldType": {
+            "fieldType": {
+              "primitiveType": "i64",
+              "annotations": null
+            }
+          },
+          "fid": 11,
+          "req": null
+        }
+      ]
+    },
+    {
+      "id": {
+        "name": "Service"
+      },
+      "functions": [
+        {
+          "id": {
+            "name": "mymethod"
+          },
+          "ft": {
+            "primitiveType": "i64",
+            "annotations": null
+          },
+          "fields": [
+            {
+              "id": {
+                "name": "blah"
+              },
+              "fieldType": {
+                "primitiveType": "i64",
+                "annotations": null
+              },
+              "fid": null,
+              "req": null
+            }
+          ],
+          "throws": null,
+          "annotations": null
+        }
+      ],
+      "annotations": null
+    }
+  ]
+}

--- a/test/thrift-idl.js
+++ b/test/thrift-idl.js
@@ -18,13 +18,30 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+/* eslint max-len:[0, 120] */
 'use strict';
 
-require('./tlist');
-require('./tmap');
-require('./tstruct');
-require('./boolean');
-require('./speclist');
-require('./specmap-obj');
-require('./specmap-entries');
-require('./thrift-idl');
+var idl = require('../thrift-idl');
+var fs = require('fs');
+var path = require('path');
+var test = require('tape');
+
+test('thrift IDL parser can parse thrift test files', function t(assert) {
+    var extension = '.thrift';
+    var dirname = path.join(__dirname, 'thrift');
+    var filenames = fs.readdirSync(dirname);
+    for (var index = 0; index < filenames.length; index++) {
+        var filename = filenames[index];
+        var fullFilename = path.join(dirname, filename);
+        if (filename.indexOf(extension, filename.length - extension.length) > 0) {
+            var source = fs.readFileSync(fullFilename, 'ascii');
+            try {
+                idl.parse(source);
+                assert.pass(filename);
+            } catch (err) {
+                assert.fail(filename);
+            }
+        }
+    }
+    assert.end();
+});

--- a/test/thrift/AnnotationTest.thrift
+++ b/test/thrift/AnnotationTest.thrift
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+typedef list<i32> ( cpp.template = "std::list" ) int_linked_list
+
+struct foo {
+  1: i32 bar ( presence = "required" );
+  2: i32 baz ( presence = "manual", cpp.use_pointer = "", );
+  3: i32 qux;
+  4: i32 bop;
+} (
+  cpp.type = "DenseFoo",
+  python.type = "DenseFoo",
+  java.final = "",
+  annotation.without.value,
+)
+
+exception foo_error {
+  1: i32 error_code ( foo="bar" )
+  2: string error_msg
+} (foo = "bar")
+
+typedef string ( unicode.encoding = "UTF-16" ) non_latin_string (foo="bar")
+typedef list< double ( cpp.fixed_point = "16" ) > tiny_float_list
+
+enum weekdays {
+  SUNDAY ( weekend = "yes" ),
+  MONDAY,
+  TUESDAY,
+  WEDNESDAY,
+  THURSDAY,
+  FRIDAY,
+  SATURDAY ( weekend = "yes" )
+} (foo.bar="baz")
+
+/* Note that annotations on senum values are not supported. */
+senum seasons {
+  "Spring",
+  "Summer",
+  "Fall",
+  "Winter"
+} ( foo = "bar" )
+
+service foo_service {
+  void foo() ( foo = "bar" )
+} (a.b="c")
+

--- a/test/thrift/BrokenConstants.thrift
+++ b/test/thrift/BrokenConstants.thrift
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const i64 myint = 68719476736
+const i64 broken = 9876543210987654321  // A little over 2^63
+
+enum foo {
+  bar = 68719476736
+}

--- a/test/thrift/ConstantsDemo.thrift
+++ b/test/thrift/ConstantsDemo.thrift
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace cpp yozone
+
+struct thing {
+  1: i32 hello,
+  2: i32 goodbye
+}
+
+enum enumconstants {
+  ONE = 1,
+  TWO = 2
+}
+
+// struct thing2 {
+//   /** standard docstring */
+//   1: enumconstants val = TWO
+// }
+
+typedef i32 myIntType
+const myIntType myInt = 3
+
+//const map<enumconstants,string> GEN_ENUM_NAMES = {ONE : "HOWDY", TWO: "PARTNER"}
+
+const i32 hex_const = 0x0001F
+
+const i32 GEN_ME = -3523553
+const double GEn_DUB = 325.532
+const double GEn_DU = 085.2355
+const string GEN_STRING = "asldkjasfd"
+
+const map<i32,i32> GEN_MAP = { 35532 : 233, 43523 : 853 }
+const list<i32> GEN_LIST = [ 235235, 23598352, 3253523 ]
+
+const map<i32, map<i32, i32>> GEN_MAPMAP = { 235 : { 532 : 53255, 235:235}}
+
+const map<string,i32> GEN_MAP2 = { "hello" : 233, "lkj98d" : 853, 'lkjsdf' : 098325 }
+
+const thing GEN_THING = { 'hello' : 325, 'goodbye' : 325352 }
+
+const map<i32,thing> GEN_WHAT = { 35 : { 'hello' : 325, 'goodbye' : 325352 } }
+
+const set<i32> GEN_SET = [ 235, 235, 53235 ]
+
+exception Blah {
+  1:  i32 bing }
+
+exception Gak {}
+
+service yowza {
+  void blingity(),
+  i32 blangity() throws (1: Blah hoot )
+}

--- a/test/thrift/DebugProtoTest.thrift
+++ b/test/thrift/DebugProtoTest.thrift
@@ -1,0 +1,367 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace c_glib TTest
+namespace cpp thrift.test.debug
+namespace java thrift.test
+
+struct Doubles {
+ 1: double nan,
+ 2: double inf,
+ 3: double neginf,
+ 4: double repeating,
+ 5: double big,
+ 6: double tiny,
+ 7: double zero,
+ 8: double negzero,
+}
+
+struct OneOfEach {
+  1: bool im_true,
+  2: bool im_false,
+  3: byte a_bite = 0x7f,
+  4: i16 integer16 = 0x7fff,
+  5: i32 integer32,
+  6: i64 integer64 = 10000000000,
+  7: double double_precision,
+  8: string some_characters,
+  9: string zomg_unicode,
+  10: bool what_who,
+  11: binary base64,
+  12: list<byte> byte_list = [1, 2, 3],
+  13: list<i16> i16_list = [1,2,3],
+  14: list<i64> i64_list = [1,2,3]
+}
+
+struct Bonk {
+  1: i32 type,
+  2: string message,
+}
+
+struct Nesting {
+  1: Bonk my_bonk,
+  2: OneOfEach my_ooe,
+}
+
+struct HolyMoley {
+  1: list<OneOfEach> big,
+  2: set<list<string>> contain,
+  3: map<string,list<Bonk>> bonks,
+}
+
+struct Backwards {
+  2: i32 first_tag2,
+  1: i32 second_tag1,
+}
+
+struct Empty {
+}
+
+struct Wrapper {
+  1: Empty foo
+}
+
+struct RandomStuff {
+  1: i32 a,
+  2: i32 b,
+  3: i32 c,
+  4: i32 d,
+  5: list<i32> myintlist,
+  6: map<i32,Wrapper> maps,
+  7: i64 bigint,
+  8: double triple,
+}
+
+struct Base64 {
+  1: i32 a,
+  2: binary b1,
+  3: binary b2,
+  4: binary b3,
+  5: binary b4,
+  6: binary b5,
+  7: binary b6,
+}
+
+struct CompactProtoTestStruct {
+  // primitive fields
+  1: byte   a_byte;
+  2: i16    a_i16;
+  3: i32    a_i32;
+  4: i64    a_i64;
+  5: double a_double;
+  6: string a_string;
+  7: binary a_binary;
+  8: bool   true_field;
+  9: bool   false_field;
+  10: Empty empty_struct_field;
+
+  // primitives in lists
+  11: list<byte>    byte_list;
+  12: list<i16>     i16_list;
+  13: list<i32>     i32_list;
+  14: list<i64>     i64_list;
+  15: list<double>  double_list;
+  16: list<string>  string_list;
+  17: list<binary>  binary_list;
+  18: list<bool>    boolean_list;
+  19: list<Empty>   struct_list;
+
+  // primitives in sets
+  20: set<byte>     byte_set;
+  21: set<i16>      i16_set;
+  22: set<i32>      i32_set;
+  23: set<i64>      i64_set;
+  24: set<double>   double_set;
+  25: set<string>   string_set;
+  26: set<binary>   binary_set;
+  27: set<bool>     boolean_set;
+  28: set<Empty>    struct_set;
+
+  // maps
+  // primitives as keys
+  29: map<byte, byte>             byte_byte_map;
+  30: map<i16, byte>              i16_byte_map;
+  31: map<i32, byte>              i32_byte_map;
+  32: map<i64, byte>              i64_byte_map;
+  33: map<double, byte>           double_byte_map;
+  34: map<string, byte>           string_byte_map;
+  35: map<binary, byte>           binary_byte_map;
+  36: map<bool, byte>             boolean_byte_map;
+  // primitives as values
+  37: map<byte, i16>              byte_i16_map;
+  38: map<byte, i32>              byte_i32_map;
+  39: map<byte, i64>              byte_i64_map;
+  40: map<byte, double>           byte_double_map;
+  41: map<byte, string>           byte_string_map;
+  42: map<byte, binary>           byte_binary_map;
+  43: map<byte, bool>             byte_boolean_map;
+  // collections as keys
+  44: map<list<byte>, byte>       list_byte_map;
+  45: map<set<byte>, byte>        set_byte_map;
+  46: map<map<byte,byte>, byte>   map_byte_map;
+  // collections as values
+  47: map<byte, map<byte,byte>>   byte_map_map;
+  48: map<byte, set<byte>>        byte_set_map;
+  49: map<byte, list<byte>>       byte_list_map;
+}
+
+// To be used to test the serialization of an empty map
+struct SingleMapTestStruct {
+  1: required map<i32, i32>       i32_map;
+}
+
+const CompactProtoTestStruct COMPACT_TEST = {
+  'a_byte'             : 127,
+  'a_i16'              : 32000,
+  'a_i32'              : 1000000000,
+  'a_i64'              : 0xffffffffff,
+  'a_double'           : 5.6789,
+  'a_string'           : "my string",
+//'a_binary,'
+  'true_field'         : 1,
+  'false_field'        : 0,
+  'empty_struct_field' : {},
+  'byte_list'          : [-127, -1, 0, 1, 127],
+  'i16_list'           : [-1, 0, 1, 0x7fff],
+  'i32_list'           : [-1, 0, 0xff, 0xffff, 0xffffff, 0x7fffffff],
+  'i64_list'           : [-1, 0, 0xff, 0xffff, 0xffffff, 0xffffffff, 0xffffffffff, 0xffffffffffff, 0xffffffffffffff, 0x7fffffffffffffff],
+  'double_list'        : [0.1, 0.2, 0.3],
+  'string_list'        : ["first", "second", "third"],
+//'binary_list,'
+  'boolean_list'       : [1, 1, 1, 0, 0, 0],
+  'struct_list'        : [{}, {}],
+  'byte_set'           : [-127, -1, 0, 1, 127],
+  'i16_set'            : [-1, 0, 1, 0x7fff],
+  'i32_set'            : [1, 2, 3],
+  'i64_set'            : [-1, 0, 0xff, 0xffff, 0xffffff, 0xffffffff, 0xffffffffff, 0xffffffffffff, 0xffffffffffffff, 0x7fffffffffffffff],
+  'double_set'         : [0.1, 0.2, 0.3],
+  'string_set'         : ["first", "second", "third"],
+//'binary_set,'
+  'boolean_set'        : [1, 0],
+  'struct_set'         : [{}],
+  'byte_byte_map'      : {1 : 2},
+  'i16_byte_map'       : {1 : 1, -1 : 1, 0x7fff : 1},
+  'i32_byte_map'       : {1 : 1, -1 : 1, 0x7fffffff : 1},
+  'i64_byte_map'       : {0 : 1,  1 : 1, -1 : 1, 0x7fffffffffffffff : 1},
+  'double_byte_map'    : {-1.1 : 1, 1.1 : 1},
+  'string_byte_map'    : {"first" : 1, "second" : 2, "third" : 3, "" : 0},
+//'binary_byte_map,'
+  'boolean_byte_map'   : {1 : 1, 0 : 0},
+  'byte_i16_map'       : {1 : 1, 2 : -1, 3 : 0x7fff},
+  'byte_i32_map'       : {1 : 1, 2 : -1, 3 : 0x7fffffff},
+  'byte_i64_map'       : {1 : 1, 2 : -1, 3 : 0x7fffffffffffffff},
+  'byte_double_map'    : {1 : 0.1, 2 : -0.1, 3 : 1000000.1},
+  'byte_string_map'    : {1 : "", 2 : "blah", 3 : "loooooooooooooong string"},
+//'byte_binary_map,'
+  'byte_boolean_map'   : {1 : 1, 2 : 0},
+  'list_byte_map'      : {[1, 2, 3] : 1, [0, 1] : 2, [] : 0},
+  'set_byte_map'       : {[1, 2, 3] : 1, [0, 1] : 2, [] : 0},
+  'map_byte_map'       : {{1 : 1} : 1, {2 : 2} : 2, {} : 0},
+  'byte_map_map'       : {0 : {}, 1 : {1 : 1}, 2 : {1 : 1, 2 : 2}},
+  'byte_set_map'       : {0 : [], 1 : [1], 2 : [1, 2]},
+  'byte_list_map'      : {0 : [], 1 : [1], 2 : [1, 2]},
+}
+
+
+const i32 MYCONST = 2
+
+
+exception ExceptionWithAMap {
+  1: string blah;
+  2: map<string, string> map_field;
+}
+
+service ServiceForExceptionWithAMap {
+  void methodThatThrowsAnException() throws (1: ExceptionWithAMap xwamap);
+}
+
+service Srv {
+  i32 Janky(1: i32 arg);
+
+  // return type only methods
+
+  void voidMethod();
+  i32 primitiveMethod();
+  CompactProtoTestStruct structMethod();
+
+  void methodWithDefaultArgs(1: i32 something = MYCONST);
+
+  oneway void onewayMethod();
+}
+
+service Inherited extends Srv {
+  i32 identity(1: i32 arg)
+}
+
+service EmptyService {}
+
+// The only purpose of this thing is to increase the size of the generated code
+// so that ZlibTest has more highly compressible data to play with.
+struct BlowUp {
+  1: map<list<i32>,set<map<i32,string>>> b1;
+  2: map<list<i32>,set<map<i32,string>>> b2;
+  3: map<list<i32>,set<map<i32,string>>> b3;
+  4: map<list<i32>,set<map<i32,string>>> b4;
+}
+
+
+struct ReverseOrderStruct {
+  4: string first;
+  3: i16 second;
+  2: i32 third;
+  1: i64 fourth;
+}
+
+service ReverseOrderService {
+  void myMethod(4: string first, 3: i16 second, 2: i32 third, 1: i64 fourth);
+}
+
+enum SomeEnum {
+  ONE = 1
+  TWO = 2
+}
+
+/** This is a docstring on a constant! */
+const SomeEnum MY_SOME_ENUM = SomeEnum.ONE
+
+const SomeEnum MY_SOME_ENUM_1 = 1
+/*const SomeEnum MY_SOME_ENUM_2 = 7*/
+
+const map<SomeEnum,SomeEnum> MY_ENUM_MAP = {
+  SomeEnum.ONE : SomeEnum.TWO
+}
+
+struct StructWithSomeEnum {
+  1: SomeEnum blah;
+}
+
+const map<SomeEnum,StructWithSomeEnum> EXTRA_CRAZY_MAP = {
+  SomeEnum.ONE : {"blah" : SomeEnum.TWO}
+}
+
+union TestUnion {
+  /**
+   * A doc string
+   */
+  1: string string_field;
+  2: i32 i32_field;
+  3: OneOfEach struct_field;
+  4: list<RandomStuff> struct_list;
+  5: i32 other_i32_field;
+  6: SomeEnum enum_field;
+  7: set<i32> i32_set;
+  8: map<i32, i32> i32_map;
+}
+
+union TestUnionMinusStringField {
+  2: i32 i32_field;
+  3: OneOfEach struct_field;
+  4: list<RandomStuff> struct_list;
+  5: i32 other_i32_field;
+  6: SomeEnum enum_field;
+  7: set<i32> i32_set;
+  8: map<i32, i32> i32_map;
+}
+
+union ComparableUnion {
+  1: string string_field;
+  2: binary binary_field;
+}
+
+struct StructWithAUnion {
+  1: TestUnion test_union;
+}
+
+struct PrimitiveThenStruct {
+  1: i32 blah;
+  2: i32 blah2;
+  3: Backwards bw;
+}
+
+typedef map<i32,i32> SomeMap
+
+struct StructWithASomemap {
+  1: required SomeMap somemap_field;
+}
+
+struct BigFieldIdStruct {
+  1: string field1;
+  45: string field2;
+}
+
+struct BreaksRubyCompactProtocol {
+  1: string field1;
+  2: BigFieldIdStruct field2;
+  3: i32 field3;
+}
+
+struct TupleProtocolTestStruct {
+  optional i32 field1;
+  optional i32 field2;
+  optional i32 field3;
+  optional i32 field4;
+  optional i32 field5;
+  optional i32 field6;
+  optional i32 field7;
+  optional i32 field8;
+  optional i32 field9;
+  optional i32 field10;
+  optional i32 field11;
+  optional i32 field12;
+}

--- a/test/thrift/DenseLinkingTest.thrift
+++ b/test/thrift/DenseLinkingTest.thrift
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+../compiler/cpp/thrift -gen cpp:dense DebugProtoTest.thrift
+../compiler/cpp/thrift -gen cpp:dense DenseLinkingTest.thrift
+g++ -Wall -g -I../lib/cpp/src -I/usr/local/include/boost-1_33_1 \
+  DebugProtoTest.cpp gen-cpp/DebugProtoTest_types.cpp \
+  gen-cpp/DenseLinkingTest_types.cpp \
+  ../lib/cpp/.libs/libthrift.a -o DebugProtoTest
+./DebugProtoTest
+*/
+
+/*
+The idea of this test is that everything is structurally identical to DebugProtoTest.
+If I messed up the naming of the reflection local typespecs,
+then compiling this should give errors because of doubly defined symbols.
+*/
+
+namespace cpp thrift.test
+namespace java thrift.test
+
+struct OneOfEachZZ {
+  1: bool im_true,
+  2: bool im_false,
+  3: byte a_bite,
+  4: i16 integer16,
+  5: i32 integer32,
+  6: i64 integer64,
+  7: double double_precision,
+  8: string some_characters,
+  9: string zomg_unicode,
+  10: bool what_who,
+}
+
+struct BonkZZ {
+  1: i32 type,
+  2: string message,
+}
+
+struct NestingZZ {
+  1: BonkZZ my_bonk,
+  2: OneOfEachZZ my_ooe,
+}
+
+struct HolyMoleyZZ {
+  1: list<OneOfEachZZ> big,
+  2: set<list<string>> contain,
+  3: map<string,list<BonkZZ>> bonks,
+}
+
+struct BackwardsZZ {
+  2: i32 first_tag2,
+  1: i32 second_tag1,
+}
+
+struct EmptyZZ {
+}
+
+struct WrapperZZ {
+  1: EmptyZZ foo
+}
+
+struct RandomStuffZZ {
+  1: i32 a,
+  2: i32 b,
+  3: i32 c,
+  4: i32 d,
+  5: list<i32> myintlist,
+  6: map<i32,WrapperZZ> maps,
+  7: i64 bigint,
+  8: double triple,
+}
+
+service Srv {
+  i32 Janky(1: i32 arg)
+}
+
+service UnderscoreSrv {
+  i64 some_rpc_call(1: string message)
+}
+

--- a/test/thrift/DocTest.thrift
+++ b/test/thrift/DocTest.thrift
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Program doctext.
+ *
+ * Seriously, this is the documentation for this whole program.
+ */
+
+namespace java thrift.test
+namespace cpp thrift.test
+
+// C++ comment
+/* c style comment */
+
+# the new unix comment
+
+/** Some doc text goes here.  Wow I am [nesting these] (no more nesting.) */
+enum Numberz
+{
+
+  /** This is how to document a parameter */
+  ONE = 1,
+
+  /** And this is a doc for a parameter that has no specific value assigned */
+  TWO,
+
+  THREE,
+  FIVE = 5,
+  SIX,
+  EIGHT = 8
+}
+
+/** This is how you would do a typedef doc */
+typedef i64 UserId
+
+/** And this is where you would document a struct */
+struct Xtruct
+{
+
+  /** And the members of a struct */
+  1:  string string_thing
+
+  /** doct text goes before a comma */
+  4:  byte   byte_thing,
+
+  9:  i32    i32_thing,
+  11: i64    i64_thing
+}
+
+/**
+ * You can document constants now too.  Yeehaw!
+ */
+const i32 INT32CONSTANT = 9853
+const i16 INT16CONSTANT = 1616
+/** Everyone get in on the docu-action! */
+const map<string,string> MAPCONSTANT = {'hello':'world', 'goodnight':'moon'}
+
+struct Xtruct2
+{
+  1: byte   byte_thing,
+  2: Xtruct struct_thing,
+  3: i32    i32_thing
+}
+
+/** Struct insanity */
+struct Insanity
+{
+
+  /** This is doc for field 1 */
+  1: map<Numberz, UserId> userMap,
+
+  /** And this is doc for field 2 */
+  2: list<Xtruct> xtructs
+}
+
+exception Xception {
+  1: i32 errorCode,
+  2: string message
+}
+
+exception Xception2 {
+  1: i32 errorCode,
+  2: Xtruct struct_thing
+}
+
+/* C1 */
+/** Doc */
+/* C2 */
+/* C3 */
+struct EmptyStruct {}
+
+struct OneField {
+  1: EmptyStruct field
+}
+
+/** This is where you would document a Service */
+service ThriftTest
+{
+
+  /** And this is how you would document functions in a service */
+  void         testVoid(),
+  string       testString(1: string thing),
+  byte         testByte(1: byte thing),
+  i32          testI32(1: i32 thing),
+
+  /** Like this one */
+  i64          testI64(1: i64 thing),
+  double       testDouble(1: double thing),
+  Xtruct       testStruct(1: Xtruct thing),
+  Xtruct2      testNest(1: Xtruct2 thing),
+  map<i32,i32> testMap(1: map<i32,i32> thing),
+  set<i32>     testSet(1: set<i32> thing),
+  list<i32>    testList(1: list<i32> thing),
+
+  /** This is an example of a function with params documented */
+  Numberz      testEnum(
+
+    /** This param is a thing */
+    1: Numberz thing
+
+  ),
+
+  UserId       testTypedef(1: UserId thing),
+
+  map<i32,map<i32,i32>> testMapMap(1: i32 hello),
+
+  /* So you think you've got this all worked, out eh? */
+  map<UserId, map<Numberz,Insanity>> testInsanity(1: Insanity argument),
+
+}
+
+/// This style of Doxy-comment doesn't work.
+typedef i32 SorryNoGo
+
+/**
+ * This is a trivial example of a multiline docstring.
+ */
+typedef i32 TrivialMultiLine
+
+/**
+ * This is the canonical example
+ * of a multiline docstring.
+ */
+typedef i32 StandardMultiLine
+
+/**
+ * The last line is non-blank.
+ * I said non-blank! */
+typedef i32 LastLine
+
+/** Both the first line
+ * are non blank. ;-)
+ * and the last line */
+typedef i32 FirstAndLastLine
+
+/**
+ *    INDENTED TITLE
+ * The text is less indented.
+ */
+typedef i32 IndentedTitle
+
+/**       First line indented.
+ * Unfortunately, this does not get indented.
+ */
+typedef i32 FirstLineIndent
+
+
+/**
+ * void code_in_comment() {
+ *   printf("hooray code!");
+ * }
+ */
+typedef i32 CodeInComment
+
+    /**
+     * Indented Docstring.
+     * This whole docstring is indented.
+     *   This line is indented further.
+     */
+typedef i32 IndentedDocstring
+
+/** Irregular docstring.
+ * We will have to punt
+  * on this thing */
+typedef i32 Irregular1
+
+/**
+ * note the space
+ * before these lines
+* but not this
+ * one
+ */
+typedef i32 Irregular2
+
+/**
+* Flush against
+* the left.
+*/
+typedef i32 Flush
+
+/**
+  No stars in this one.
+  It should still work fine, though.
+    Including indenting.
+    */
+typedef i32 NoStars
+
+/** Trailing whitespace   
+Sloppy trailing whitespace   
+is truncated.   */
+typedef i32 TrailingWhitespace
+
+/**
+ * This is a big one.
+ *
+ * We'll have some blank lines in it.
+ * 
+ * void as_well_as(some code) {
+ *   puts("YEEHAW!");
+ * }
+ */
+typedef i32 BigDog
+
+/**
+*
+*
+*/
+typedef i32 TotallyDegenerate
+
+/**no room for newline here*/
+
+/* THE END */

--- a/test/thrift/EnumTest.thrift
+++ b/test/thrift/EnumTest.thrift
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Contains some contributions under the Thrift Software License.
+ * Please see doc/old-thrift-license.txt in the Thrift distribution for
+ * details.
+ */
+
+enum MyEnum1 {
+  ME1_0 = 0,
+  ME1_1 = 1,
+  ME1_2,
+  ME1_3,
+  ME1_5 = 5,
+  ME1_6,
+}
+
+enum MyEnum2 {
+  ME2_0,
+  ME2_1,
+  ME2_2,
+}
+
+enum MyEnum2_again {
+  // enum value identifiers may appear again in another enum type
+  ME0_1,
+  ME1_1,
+  ME2_1,
+  ME3_1,
+}
+
+enum MyEnum3 {
+  ME3_0,
+  ME3_1,
+  ME3_N2 = -2,
+  ME3_N1,
+  ME3_D0,
+  ME3_D1,
+  ME3_9 = 9,
+  ME3_10,
+}
+
+enum MyEnum4 {
+  ME4_A = 0x7ffffffd
+  ME4_B
+  ME4_C
+  // attempting to define another enum value here fails
+  // with an overflow error, as we overflow values that can be
+  // represented with an i32.
+}
+
+struct MyStruct {
+  1: MyEnum2 me2_2 = MyEnum1.ME2_2
+  2: MyEnum3 me3_n2 = MyEnum3.ME3_N2
+  3: MyEnum3 me3_d1 = MyEnum3.ME3_D1
+}
+

--- a/test/thrift/Include.thrift
+++ b/test/thrift/Include.thrift
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+include "ThriftTest.thrift"
+
+struct IncludeTest {
+  1: required ThriftTest.Bools bools
+}

--- a/test/thrift/JavaBeansTest.thrift
+++ b/test/thrift/JavaBeansTest.thrift
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace java thrift.test
+
+struct OneOfEachBeans {
+  1: bool boolean_field,
+  2: byte a_bite,
+  3: i16 integer16,
+  4: i32 integer32,
+  5: i64 integer64,
+  6: double double_precision,
+  7: string some_characters,
+  8: binary base64,
+  9: list<byte> byte_list,
+  10: list<i16> i16_list,
+  11: list<i64> i64_list
+}
+
+
+service Service {
+  i64 mymethod(i64 blah);
+}

--- a/test/thrift/ManyOptionals.thrift
+++ b/test/thrift/ManyOptionals.thrift
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The java codegenerator has a few different codepaths depending
+// on how many optionals the struct has; this attempts to exercise
+// them.
+
+namespace java thrift.test
+
+struct Opt4 {
+  1: i32 def1;
+  2: i32 def2;
+  3: i32 def3;
+  4: i32 def4;
+}
+
+struct Opt13 {
+  1: i32 def1;
+  2: i32 def2;
+  3: i32 def3;
+  4: i32 def4;
+  5: i32 def5;
+  6: i32 def6;
+  7: i32 def7;
+  8: i32 def8;
+  9: i32 def9;
+  10: i32 def10;
+  11: i32 def11;
+  12: i32 def12;
+  13: i32 def13;
+}
+
+struct Opt30 {
+  1: i32 def1;
+  2: i32 def2;
+  3: i32 def3;
+  4: i32 def4;
+  5: i32 def5;
+  6: i32 def6;
+  7: i32 def7;
+  8: i32 def8;
+  9: i32 def9;
+  10: i32 def10;
+  11: i32 def11;
+  12: i32 def12;
+  13: i32 def13;
+  14: i32 def14;
+  15: i32 def15;
+  16: i32 def16;
+  17: i32 def17;
+  18: i32 def18;
+  19: i32 def19;
+  20: i32 def20;
+  21: i32 def21;
+  22: i32 def22;
+  23: i32 def23;
+  24: i32 def24;
+  25: i32 def25;
+  26: i32 def26;
+  27: i32 def27;
+  28: i32 def28;
+  29: i32 def29;
+  30: i32 def30;
+}
+
+struct Opt64 {
+  1: i32 def1;
+  2: i32 def2;
+  3: i32 def3;
+  4: i32 def4;
+  5: i32 def5;
+  6: i32 def6;
+  7: i32 def7;
+  8: i32 def8;
+  9: i32 def9;
+  10: i32 def10;
+  11: i32 def11;
+  12: i32 def12;
+  13: i32 def13;
+  14: i32 def14;
+  15: i32 def15;
+  16: i32 def16;
+  17: i32 def17;
+  18: i32 def18;
+  19: i32 def19;
+  20: i32 def20;
+  21: i32 def21;
+  22: i32 def22;
+  23: i32 def23;
+  24: i32 def24;
+  25: i32 def25;
+  26: i32 def26;
+  27: i32 def27;
+  28: i32 def28;
+  29: i32 def29;
+  30: i32 def30;
+  31: i32 def31;
+  32: i32 def32;
+  33: i32 def33;
+  34: i32 def34;
+  35: i32 def35;
+  36: i32 def36;
+  37: i32 def37;
+  38: i32 def38;
+  39: i32 def39;
+  40: i32 def40;
+  41: i32 def41;
+  42: i32 def42;
+  43: i32 def43;
+  44: i32 def44;
+  45: i32 def45;
+  46: i32 def46;
+  47: i32 def47;
+  48: i32 def48;
+  49: i32 def49;
+  50: i32 def50;
+  51: i32 def51;
+  52: i32 def52;
+  53: i32 def53;
+  54: i32 def54;
+  55: i32 def55;
+  56: i32 def56;
+  57: i32 def57;
+  58: i32 def58;
+  59: i32 def59;
+  60: i32 def60;
+  61: i32 def61;
+  62: i32 def62;
+  63: i32 def63;
+  64: i32 def64;
+}
+
+struct Opt80 {
+  1: i32 def1;
+  2: i32 def2;
+  3: i32 def3;
+  4: i32 def4;
+  5: i32 def5;
+  6: i32 def6;
+  7: i32 def7;
+  8: i32 def8;
+  9: i32 def9;
+  10: i32 def10;
+  11: i32 def11;
+  12: i32 def12;
+  13: i32 def13;
+  14: i32 def14;
+  15: i32 def15;
+  16: i32 def16;
+  17: i32 def17;
+  18: i32 def18;
+  19: i32 def19;
+  20: i32 def20;
+  21: i32 def21;
+  22: i32 def22;
+  23: i32 def23;
+  24: i32 def24;
+  25: i32 def25;
+  26: i32 def26;
+  27: i32 def27;
+  28: i32 def28;
+  29: i32 def29;
+  30: i32 def30;
+  31: i32 def31;
+  32: i32 def32;
+  33: i32 def33;
+  34: i32 def34;
+  35: i32 def35;
+  36: i32 def36;
+  37: i32 def37;
+  38: i32 def38;
+  39: i32 def39;
+  40: i32 def40;
+  41: i32 def41;
+  42: i32 def42;
+  43: i32 def43;
+  44: i32 def44;
+  45: i32 def45;
+  46: i32 def46;
+  47: i32 def47;
+  48: i32 def48;
+  49: i32 def49;
+  50: i32 def50;
+  51: i32 def51;
+  52: i32 def52;
+  53: i32 def53;
+  54: i32 def54;
+  55: i32 def55;
+  56: i32 def56;
+  57: i32 def57;
+  58: i32 def58;
+  59: i32 def59;
+  60: i32 def60;
+  61: i32 def61;
+  62: i32 def62;
+  63: i32 def63;
+  64: i32 def64;
+  65: i32 def65;
+  66: i32 def66;
+  67: i32 def67;
+  68: i32 def68;
+  69: i32 def69;
+  70: i32 def70;
+  71: i32 def71;
+  72: i32 def72;
+  73: i32 def73;
+  74: i32 def74;
+  75: i32 def75;
+  76: i32 def76;
+  77: i32 def77;
+  78: i32 def78;
+  79: i32 def79;
+  80: i32 def80;
+}
+

--- a/test/thrift/ManyTypedefs.thrift
+++ b/test/thrift/ManyTypedefs.thrift
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// This is to make sure you don't mess something up when you change typedef code.
+// Generate it with the old and new thrift and make sure they are the same.
+/*
+rm -rf gen-* orig-*
+mkdir old new
+thrift --gen cpp --gen java --gen php --gen phpi --gen py --gen rb --gen xsd --gen perl --gen ocaml --gen erl --gen hs --strict ManyTypedefs.thrift
+mv gen-* old
+../compiler/cpp/thrift --gen cpp --gen java --gen php --gen phpi --gen py --gen rb --gen xsd --gen perl --gen ocaml --gen erl --gen hs --strict ManyTypedefs.thrift
+mv gen-* new
+diff -ur old new
+rm -rf old new
+# There should be no output.
+*/
+
+typedef i32 int32
+typedef list<map<int32, string>> biglist
+
+struct struct1 {
+  1: int32 myint;
+  2: biglist mylist;
+}
+
+exception exception1 {
+  1: biglist alist;
+  2: struct1 mystruct;
+}
+
+service AService {
+  struct1 method1(1: int32 myint) throws (1: exception1 exn);
+  biglist method2();
+}

--- a/test/thrift/NameConflictTest.thrift
+++ b/test/thrift/NameConflictTest.thrift
@@ -1,0 +1,110 @@
+// Naming testcases, sepcifically for these tickets (but not limited to them)
+// THRIFT-2508 Uncompileable C# code due to language keywords in IDL
+// THRIFT-2557 error CS0542 member names cannot be the same as their enclosing type
+
+
+struct using {
+    1: double single
+    2: double integer
+}
+
+struct delegate {
+    1: string partial
+    2: delegate delegate
+}
+
+struct get {
+    1: bool sbyte
+}
+
+struct partial {
+    1: using using
+    2: bool read
+    3: bool write
+}
+
+enum Maybe {
+  JUST = 1,
+  TRUE = 2,
+  FALSE = 3
+}
+
+enum Either {
+  LEFT = 1,
+  RIGHT = 2
+}
+
+struct foldr {
+  1: string id
+}
+
+struct of {
+  1: string let
+  2: string where
+}
+
+struct ofOf {
+  1: of Of
+}
+
+
+struct ClassAndProp {
+  1: bool ClassAndProp
+  2: bool ClassAndProp_
+  3: bool ClassAndProp__
+  4: bool ClassAndProper
+}
+
+struct second_chance {
+  1: bool SECOND_CHANCE
+  2: bool SECOND_CHANCE_
+  3: bool SECOND_CHANCE__
+  4: bool SECOND_CHANCES
+}
+
+struct NOW_EAT_THIS {
+  1: bool now_eat_this
+  2: bool now_eat_this_
+  3: bool now_eat_this__
+  4: bool now_eat_this_and_this
+}
+
+struct TheEdgeCase {
+  1: bool theEdgeCase
+  2: bool theEdgeCase_
+  3: bool theEdgeCase__
+  4: bool TheEdgeCase
+  5: bool TheEdgeCase_
+  6: bool TheEdgeCase__
+}
+
+struct Tricky_ {
+  1: bool tricky
+  2: bool Tricky
+}
+
+struct Nested {
+  1: ClassAndProp ClassAndProp
+  2: second_chance second_chance
+  3: NOW_EAT_THIS NOW_EAT_THIS
+  4: TheEdgeCase TheEdgeCase
+  5: Tricky_ Tricky_
+  6: Nested Nested
+}
+
+exception Problem_ {
+  1: bool problem
+  2: bool Problem
+}
+
+
+service extern {
+    delegate event(1: partial get)
+    void Foo(1: Nested Foo_args) throws (1: Problem_ Foo_result)
+}
+
+service qualified {
+    Maybe maybe(1: Maybe foldr)
+    Either either(1: foldr of)
+}
+// eof

--- a/test/thrift/OptionalRequiredTest.thrift
+++ b/test/thrift/OptionalRequiredTest.thrift
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Contains some contributions under the Thrift Software License.
+ * Please see doc/old-thrift-license.txt in the Thrift distribution for
+ * details.
+ */
+
+namespace c_glib TTest
+namespace cpp thrift.test
+namespace java thrift.test
+
+struct OldSchool {
+  1: i16    im_int;
+  2: string im_str;
+  3: list<map<i32,string>> im_big;
+}
+
+struct Simple {
+  1: /* :) */ i16 im_default;
+  2: required i16 im_required;
+  3: optional i16 im_optional;
+}
+
+struct Tricky1 {
+  1: /* :) */ i16 im_default;
+}
+
+struct Tricky2 {
+  1: optional i16 im_optional;
+}
+
+struct Tricky3 {
+  1: required i16 im_required;
+}
+
+struct OptionalDefault {
+  1: optional i16 opt_int = 1234;
+  2: optional string opt_str = "default";
+}
+
+struct Complex {
+  1:          i16 cp_default;
+  2: required i16 cp_required;
+  3: optional i16 cp_optional;
+  4:          map<i16,Simple> the_map;
+  5: required Simple req_simp;
+  6: optional Simple opt_simp;
+}
+
+struct ManyOpt {
+  1: optional i32 opt1;
+  2: optional i32 opt2;
+  3: optional i32 opt3;
+  4:          i32 def4;
+  5: optional i32 opt5;
+  6: optional i32 opt6;
+}
+
+struct JavaTestHelper {
+  1: required i32    req_int;
+  2: optional i32    opt_int;
+  3: required string req_obj;
+  4: optional string opt_obj;
+  5: required binary req_bin;
+  6: optional binary opt_bin;
+}

--- a/test/thrift/Recursive.thrift
+++ b/test/thrift/Recursive.thrift
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+struct RecTree {
+  1: list<RecTree> children
+  2: i16 item
+}
+
+struct RecList {
+  1: RecList & nextitem
+  3: i16 item
+}
+
+struct CoRec {
+  1:  CoRec2 & other
+}
+
+struct CoRec2 {
+  1: CoRec other
+}
+
+struct VectorTest {
+  1: list<RecList> lister;
+}
+
+service TestService
+{
+  RecTree echoTree(1:RecTree tree)
+  RecList echoList(1:RecList lst)
+  CoRec echoCoRec(1:CoRec item)
+}

--- a/test/thrift/ReuseObjects.thrift
+++ b/test/thrift/ReuseObjects.thrift
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The java codegenerator has option to reuse objects for deserialization
+
+namespace java thrift.test
+
+include "ThriftTest.thrift"
+
+struct Reuse {
+  1: i32 val1;
+  2: set<string> val2;
+}
+

--- a/test/thrift/SmallTest.thrift
+++ b/test/thrift/SmallTest.thrift
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+namespace rb TestNamespace
+
+struct Goodbyez {
+  1: i32 val = 325;
+}
+
+senum Thinger {
+  "ASDFKJ",
+  "r32)*F#@",
+  "ASDFLJASDF"
+}
+
+struct BoolPasser {
+  1: bool value = 1
+}
+
+struct Hello {
+  1: i32 simple = 53,
+  2: map<i32,i32> complex = {23:532, 6243:632, 2355:532},
+  3: map<i32, map<i32,i32>> complexer,
+  4: string words = "words",
+  5: Goodbyez thinz = {'val' : 36632}
+}
+
+const map<i32,map<i32,i32>> CMAP = { 235: {235:235}, 53:{53:53} }
+const i32 CINT = 325;
+const Hello WHOA = {'simple' : 532}
+
+exception Goodbye {
+  1: i32 simple,
+  2: map<i32,i32> complex,
+  3: map<i32, map<i32,i32>> complexer,
+}
+
+service SmallService {
+  Thinger testThinger(1:Thinger bootz),
+  Hello testMe(1:i32 hello=64, 2: Hello wonk) throws (1: Goodbye g),
+  void testVoid() throws (1: Goodbye g),
+  i32 testI32(1:i32 boo)
+}

--- a/test/thrift/StressTest.thrift
+++ b/test/thrift/StressTest.thrift
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace cpp test.stress
+namespace d thrift.test.stress
+namespace go stress
+
+service Service {
+
+  void echoVoid(),
+  byte echoByte(1: byte arg),
+  i32 echoI32(1: i32 arg),
+  i64 echoI64(1: i64 arg),
+  string echoString(1: string arg),
+  list<byte>  echoList(1: list<byte> arg),
+  set<byte>  echoSet(1: set<byte> arg),
+  map<byte, byte>  echoMap(1: map<byte, byte> arg),
+}
+

--- a/test/thrift/ThriftTest.thrift
+++ b/test/thrift/ThriftTest.thrift
@@ -1,0 +1,393 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Contains some contributions under the Thrift Software License.
+ * Please see doc/old-thrift-license.txt in the Thrift distribution for
+ * details.
+ */
+
+namespace c_glib TTest
+namespace java thrift.test
+namespace cpp thrift.test
+namespace rb Thrift.Test
+namespace perl ThriftTest
+namespace csharp Thrift.Test
+namespace js ThriftTest
+namespace st ThriftTest
+namespace py ThriftTest
+namespace py.twisted ThriftTest
+namespace go thrifttest
+namespace php ThriftTest
+namespace delphi Thrift.Test
+namespace cocoa ThriftTest
+namespace lua ThriftTest
+
+// Presence of namespaces and sub-namespaces for which there is
+// no generator should compile with warnings only
+namespace noexist ThriftTest
+namespace cpp.noexist ThriftTest
+
+namespace * thrift.test
+
+/**
+ * Docstring!
+ */
+enum Numberz
+{
+  ONE = 1,
+  TWO,
+  THREE,
+  FIVE = 5,
+  SIX,
+  EIGHT = 8
+}
+
+const Numberz myNumberz = Numberz.ONE;
+// the following is expected to fail:
+// const Numberz urNumberz = ONE;
+
+typedef i64 UserId
+
+struct Bonk
+{
+  1: string message,
+  2: i32 type
+}
+
+typedef map<string,Bonk> MapType
+
+struct Bools {
+  1: bool im_true,
+  2: bool im_false,
+}
+
+struct Xtruct
+{
+  1:  string string_thing,
+  4:  byte   byte_thing,
+  9:  i32    i32_thing,
+  11: i64    i64_thing
+}
+
+struct Xtruct2
+{
+  1: byte   byte_thing,
+  2: Xtruct struct_thing,
+  3: i32    i32_thing
+}
+
+struct Xtruct3
+{
+  1:  string string_thing,
+  4:  i32    changed,
+  9:  i32    i32_thing,
+  11: i64    i64_thing
+}
+
+
+struct Insanity
+{
+  1: map<Numberz, UserId> userMap,
+  2: list<Xtruct> xtructs
+}
+
+struct CrazyNesting {
+  1: string string_field,
+  2: optional set<Insanity> set_field,
+  3: required list< map<set<i32>,map<i32,set<list<map<Insanity,string>>>>>> list_field,
+  4: binary binary_field
+}
+
+exception Xception {
+  1: i32 errorCode,
+  2: string message
+}
+
+exception Xception2 {
+  1: i32 errorCode,
+  2: Xtruct struct_thing
+}
+
+struct EmptyStruct {}
+
+struct OneField {
+  1: EmptyStruct field
+}
+
+service ThriftTest
+{
+  /**
+   * Prints "testVoid()" and returns nothing.
+   */
+  void         testVoid(),
+
+  /**
+   * Prints 'testString("%s")' with thing as '%s'
+   * @param string thing - the string to print
+   * @return string - returns the string 'thing'
+   */
+  string       testString(1: string thing),
+
+  /**
+   * Prints 'testByte("%d")' with thing as '%d'
+   * @param byte thing - the byte to print
+   * @return byte - returns the byte 'thing'
+   */
+  byte         testByte(1: byte thing),
+
+  /**
+   * Prints 'testI32("%d")' with thing as '%d'
+   * @param i32 thing - the i32 to print
+   * @return i32 - returns the i32 'thing'
+   */
+  i32          testI32(1: i32 thing),
+
+  /**
+   * Prints 'testI64("%d")' with thing as '%d'
+   * @param i64 thing - the i64 to print
+   * @return i64 - returns the i64 'thing'
+   */
+  i64          testI64(1: i64 thing),
+
+  /**
+   * Prints 'testDouble("%f")' with thing as '%f'
+   * @param double thing - the double to print
+   * @return double - returns the double 'thing'
+   */
+  double       testDouble(1: double thing),
+
+  /**
+   * Prints 'testBinary("%s")' where '%s' is a hex-formatted string of thing's data
+   * @param binary  thing - the binary data to print
+   * @return binary  - returns the binary 'thing'
+   */
+  binary       testBinary(1: binary thing),
+  
+  /**
+   * Prints 'testStruct("{%s}")' where thing has been formatted into a string of comma separated values
+   * @param Xtruct thing - the Xtruct to print
+   * @return Xtruct - returns the Xtruct 'thing'
+   */
+  Xtruct       testStruct(1: Xtruct thing),
+
+  /**
+   * Prints 'testNest("{%s}")' where thing has been formatted into a string of the nested struct
+   * @param Xtruct2 thing - the Xtruct2 to print
+   * @return Xtruct2 - returns the Xtruct2 'thing'
+   */
+  Xtruct2      testNest(1: Xtruct2 thing),
+
+  /**
+   * Prints 'testMap("{%s")' where thing has been formatted into a string of  'key => value' pairs
+   *  separated by commas and new lines
+   * @param map<i32,i32> thing - the map<i32,i32> to print
+   * @return map<i32,i32> - returns the map<i32,i32> 'thing'
+   */
+  map<i32,i32> testMap(1: map<i32,i32> thing),
+
+  /**
+   * Prints 'testStringMap("{%s}")' where thing has been formatted into a string of  'key => value' pairs
+   *  separated by commas and new lines
+   * @param map<string,string> thing - the map<string,string> to print
+   * @return map<string,string> - returns the map<string,string> 'thing'
+   */
+  map<string,string> testStringMap(1: map<string,string> thing),
+
+  /**
+   * Prints 'testSet("{%s}")' where thing has been formatted into a string of  values
+   *  separated by commas and new lines
+   * @param set<i32> thing - the set<i32> to print
+   * @return set<i32> - returns the set<i32> 'thing'
+   */
+  set<i32>     testSet(1: set<i32> thing),
+
+  /**
+   * Prints 'testList("{%s}")' where thing has been formatted into a string of  values
+   *  separated by commas and new lines
+   * @param list<i32> thing - the list<i32> to print
+   * @return list<i32> - returns the list<i32> 'thing'
+   */
+  list<i32>    testList(1: list<i32> thing),
+
+  /**
+   * Prints 'testEnum("%d")' where thing has been formatted into it's numeric value
+   * @param Numberz thing - the Numberz to print
+   * @return Numberz - returns the Numberz 'thing'
+   */
+  Numberz      testEnum(1: Numberz thing),
+
+  /**
+   * Prints 'testTypedef("%d")' with thing as '%d'
+   * @param UserId thing - the UserId to print
+   * @return UserId - returns the UserId 'thing'
+   */
+  UserId       testTypedef(1: UserId thing),
+
+  /**
+   * Prints 'testMapMap("%d")' with hello as '%d'
+   * @param i32 hello - the i32 to print
+   * @return map<i32,map<i32,i32>> - returns a dictionary with these values:
+   *   {-4 => {-4 => -4, -3 => -3, -2 => -2, -1 => -1, }, 4 => {1 => 1, 2 => 2, 3 => 3, 4 => 4, }, }
+   */
+  map<i32,map<i32,i32>> testMapMap(1: i32 hello),
+
+  /**
+   * So you think you've got this all worked, out eh?
+   *
+   * Creates a the returned map with these values and prints it out:
+   *   { 1 => { 2 => argument,
+   *            3 => argument,
+   *          },
+   *     2 => { 6 => <empty Insanity struct>, },
+   *   }
+   * @return map<UserId, map<Numberz,Insanity>> - a map with the above values
+   */
+  map<UserId, map<Numberz,Insanity>> testInsanity(1: Insanity argument),
+
+  /**
+   * Prints 'testMulti()'
+   * @param byte arg0 -
+   * @param i32 arg1 -
+   * @param i64 arg2 -
+   * @param map<i16, string> arg3 -
+   * @param Numberz arg4 -
+   * @param UserId arg5 -
+   * @return Xtruct - returns an Xtruct with string_thing = "Hello2, byte_thing = arg0, i32_thing = arg1
+   *    and i64_thing = arg2
+   */
+  Xtruct testMulti(1: byte arg0, 2: i32 arg1, 3: i64 arg2, 4: map<i16, string> arg3, 5: Numberz arg4, 6: UserId arg5),
+
+  /**
+   * Print 'testException(%s)' with arg as '%s'
+   * @param string arg - a string indication what type of exception to throw
+   * if arg == "Xception" throw Xception with errorCode = 1001 and message = arg
+   * elsen if arg == "TException" throw TException
+   * else do not throw anything
+   */
+  void testException(1: string arg) throws(1: Xception err1),
+
+  /**
+   * Print 'testMultiException(%s, %s)' with arg0 as '%s' and arg1 as '%s'
+   * @param string arg - a string indication what type of exception to throw
+   * if arg0 == "Xception" throw Xception with errorCode = 1001 and message = "This is an Xception"
+   * elsen if arg0 == "Xception2" throw Xception2 with errorCode = 2002 and message = "This is an Xception2"
+   * else do not throw anything
+   * @return Xtruct - an Xtruct with string_thing = arg1
+   */
+  Xtruct testMultiException(1: string arg0, 2: string arg1) throws(1: Xception err1, 2: Xception2 err2)
+
+  /**
+   * Print 'testOneway(%d): Sleeping...' with secondsToSleep as '%d'
+   * sleep 'secondsToSleep'
+   * Print 'testOneway(%d): done sleeping!' with secondsToSleep as '%d'
+   * @param i32 secondsToSleep - the number of seconds to sleep
+   */
+  oneway void testOneway(1:i32 secondsToSleep)
+}
+
+service SecondService
+{
+  void blahBlah()
+  /**
+   * Prints 'testString("%s")' with thing as '%s'
+   * @param string thing - the string to print
+   * @return string - returns the string 'thing'
+   */
+  string       secondtestString(1: string thing),
+}
+
+struct VersioningTestV1 {
+       1: i32 begin_in_both,
+       3: string old_string,
+       12: i32 end_in_both
+}
+
+struct VersioningTestV2 {
+       1: i32 begin_in_both,
+
+       2: i32 newint,
+       3: byte newbyte,
+       4: i16 newshort,
+       5: i64 newlong,
+       6: double newdouble
+       7: Bonk newstruct,
+       8: list<i32> newlist,
+       9: set<i32> newset,
+       10: map<i32, i32> newmap,
+       11: string newstring,
+       12: i32 end_in_both
+}
+
+struct ListTypeVersioningV1 {
+       1: list<i32> myints;
+       2: string hello;
+}
+
+struct ListTypeVersioningV2 {
+       1: list<string> strings;
+       2: string hello;
+}
+
+struct GuessProtocolStruct {
+  7: map<string,string> map_field,
+}
+
+struct LargeDeltas {
+  1: Bools b1,
+  10: Bools b10,
+  100: Bools b100,
+  500: bool check_true,
+  1000: Bools b1000,
+  1500: bool check_false,
+  2000: VersioningTestV2 vertwo2000,
+  2500: set<string> a_set2500,
+  3000: VersioningTestV2 vertwo3000,
+  4000: list<i32> big_numbers
+}
+
+struct NestedListsI32x2 {
+  1: list<list<i32>> integerlist
+}
+struct NestedListsI32x3 {
+  1: list<list<list<i32>>> integerlist
+}
+struct NestedMixedx2 {
+  1: list<set<i32>> int_set_list
+  2: map<i32,set<string>> map_int_strset
+  3: list<map<i32,set<string>>> map_int_strset_list
+}
+struct ListBonks {
+  1: list<Bonk> bonk
+}
+struct NestedListsBonk {
+  1: list<list<list<Bonk>>> bonk
+}
+
+struct BoolTest {
+  1: optional bool b = true;
+  2: optional string s = "true";
+}
+
+struct StructA {
+  1: required string s;
+}
+
+struct StructB {
+  1: optional StructA aa;
+  2: required StructA ab;
+}

--- a/test/thrift/TypedefTest.thrift
+++ b/test/thrift/TypedefTest.thrift
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Contains some contributions under the Thrift Software License.
+ * Please see doc/old-thrift-license.txt in the Thrift distribution for
+ * details.
+ */
+
+namespace cpp thrift.test
+
+typedef i32 MyInt32
+typedef string MyString;
+
+struct TypedefTestStruct {
+  1: MyInt32 field_MyInt32;
+  2: MyString field_MyString;
+  3: i32 field_Int32;
+  4: string field_String;
+}
+
+typedef TypedefTestStruct MyStruct,

--- a/thrift-idl.js
+++ b/thrift-idl.js
@@ -20,11 +20,15 @@
 
 'use strict';
 
-require('./tlist');
-require('./tmap');
-require('./tstruct');
-require('./boolean');
-require('./speclist');
-require('./specmap-obj');
-require('./specmap-entries');
-require('./thrift-idl');
+var PEG = require('pegjs');
+var fs = require('fs');
+var path = require('path');
+
+var grammarPath = path.join(__dirname, 'thrift-idl.pegjs');
+var grammar = PEG.buildParser(fs.readFileSync(grammarPath).toString('ascii'));
+
+function parse(source) {
+    return grammar.parse(source);
+}
+
+module.exports.parse = parse;

--- a/thrift-idl.pegjs
+++ b/thrift-idl.pegjs
@@ -1,0 +1,706 @@
+{
+
+    function Program(headers, definitions) {
+        this.headers = headers;
+        this.definitions = definitions;
+    }
+    Program.prototype.type = 'Program';
+
+    function Identifier(name) {
+        this.name = name;
+    }
+    Identifier.prototype.type = 'Identifier';
+
+    function Namespace(name, scope) {
+        this.name = name;
+        this.scope = scope;
+    }
+    Namespace.prototype.type = 'Namespace';
+
+    function Typedef(type, name, annotations) {
+        this.typedefType = type;
+        this.name = name;
+        this.annotations = annotations;
+    }
+    Typedef.prototype.type = 'Typedef';
+
+    function BaseType(type, annotations) {
+        this.baseType = type;
+        this.annotations = annotations;
+    }
+    BaseType.prototype.type = 'BaseType';
+
+    function Enum(name, definitions, annotations) {
+        this.name = name;
+        this.enumDefinitions = definitions;
+        this.annotations = annotations;
+    }
+    Enum.prototype.type = 'Enum';
+
+    function EnumDefinition(name, value, annotations) {
+        this.name = name;
+        this.value = value;
+        this.annotations = annotations;
+    }
+    EnumDefinition.prototype.type = 'EnumDefinition';
+
+    function Senum(name, definitions, annotations) {
+        this.name = name;
+        this.senumDefinitions = definitions;
+        this.annotations = annotations;
+    }
+    Senum.prototype.type = 'Senum';
+
+    function Const(name, fieldType, value) {
+        this.name = name;
+        this.fieldType = fieldType;
+        this.value = value;
+    }
+    Const.prototype.type = 'Const';
+
+    function Struct(name, fields, annotations) {
+        this.name = name;
+        this.fields = fields;
+        this.annotations = annotations;
+    }
+    Struct.prototype.type = 'Struct';
+
+    function Union(name, fields) {
+        this.name = name;
+        this.fields = fields;
+    }
+    Union.prototype.type = 'Union';
+
+    function Exception(name, fields, annotations) {
+        this.name = name;
+        this.fields = fields;
+        this.annotations = annotations;
+    }
+    Exception.prototype.type = 'Exception';
+
+    function Service(name, functions, annotations) {
+        this.name = name;
+        this.functions = functions;
+        this.annotations = annotations;
+    }
+    Service.prototype.type = 'Service';
+
+    function FunctionDescription(name, fields, ft, _throws, annotations) {
+        this.name = name;
+        this.functionType = ft;
+        this.fields = fields;
+        this.throws = _throws;
+        this.annotations = annotations;
+    }
+    FunctionDescription.prototype.type = 'function';
+
+    function Throws(fields) {
+        this.fields = fields;
+    }
+    Throws.prototype.type = 'throws';
+
+    function Field(name, ft, id, req, fv, annotations) {
+        this.id = id;
+        this.name = name;
+        this.valueType = ft;
+        this.required = req === 'required';
+        this.optional = req === 'optional';
+        this.defaultValue = fv;
+        this.annotations = annotations;
+    }
+    Field.prototype.type = 'Field';
+
+    function MapType(keyType, valueType) {
+        this.keyType = keyType;
+        this.valueType = valueType;
+    }
+    MapType.prototype.type = 'Map';
+
+    function SetType(valueType) {
+        this.valueType = valueType;
+    }
+    SetType.prototype.type = 'Set';
+
+    function ListType(valueType) {
+        this.valueType = valueType;
+    }
+    ListType.prototype.type = 'List';
+
+    function TypeAnnotation(name, value) {
+        this.name = name;
+        this.value = value;
+    }
+    TypeAnnotation.prototype.type = 'TypeAnnotation';
+
+    function Comment(value) {
+        this.value = value;
+    }
+    Comment.prototype.type = 'Comment';
+
+    function Literal(value) {
+        this.value = value;
+    }
+    Literal.prototype.type = 'Literal';
+
+}
+
+Program
+  = __ hs:Header* ds:Definition* {
+    return new Program(hs.filter(Boolean), ds);
+  }
+
+Header
+  = Include
+  / CppInclude
+  / Namespace
+  / 'cpp_namespace' IdentifierName
+  / 'php_namespace' IdentifierName
+  / 'py_module' IdentifierName
+  / 'perl_package' IdentifierName
+  / 'ruby_namespace' IdentifierName
+  / 'smalltalk_category' STIdentifierName
+  / 'smalltalk_prefix' IdentifierName
+  / 'java_package' IdentifierName
+  / 'cocoa_package' IdentifierName
+  / 'xsd_namespace' Literal
+  / 'csharp_namespace' IdentifierName
+
+Include
+  = IncludeToken Literal
+
+CppInclude
+  = CppIncludeToken Literal
+
+Namespace
+  = NamespaceToken scope:NamespaceScope __ name:IdentifierName { return new Namespace(name, scope); }
+  / NamespaceToken 'smalltalk.category' __ STIdentifierName
+  / NamespaceToken 'smalltalk.prefix' __ IdentifierName
+  / 'php_namespace' __ Literal
+  / 'xsd_namespace' __ Literal
+  / NamespaceToken scope:'*' __ IdentifierName { return; }
+  / NamespaceToken scope:IdentifierName name:IdentifierName { return; }
+
+NamespaceScope
+  = 'cpp'
+  / 'java'
+  / 'py.twisted'
+  / 'py'
+  / 'perl'
+  / 'rb'
+  / 'cocoa'
+  / 'csharp'
+  / 'php'
+  / 'as3'
+  / 'c_glib'
+  / 'js'
+  / 'st'
+  / 'go'
+  / 'delphi'
+  / 'lua'
+
+Definition
+  = Const
+  / Typedef
+  / Enum
+  / Senum
+  / Struct
+  / Union
+  / Exception
+  / Service
+
+Typedef
+  = TypedefToken __ dt:DefinitionType name:IdentifierName ta:TypeAnnotations? ListSeparator? {
+    return new Typedef(dt, name, ta);
+  }
+
+DefinitionType
+  = ft:FieldType __ { return ft; }
+
+CommaOrSemicolon
+  = ',' __
+  / ';' __
+
+ListSeparator 'list separator'
+  = CommaOrSemicolon
+
+Enum
+  = EnumToken __ name:IdentifierName __ '{' __ ed:EnumDefinition* __ '}' __ ta:TypeAnnotations? {
+    return new Enum(name, ed, ta);
+  }
+
+EnumDefinition
+  = name:IdentifierName value:('=' __ v:IntConstant { return v.value })? __ ta:TypeAnnotations? ListSeparator? __ {
+    return new EnumDefinition(name, value, ta);
+  }
+
+Senum
+  = SenumToken name:IdentifierName '{' __ ss:SenumDefinition* '}' __ ta:TypeAnnotations? {
+    return new Senum(name, ss, ta);
+  }
+
+SenumDefinition
+  = s:Literal ListSeparator? { return s; }
+
+Const
+  = ConstToken ft:FieldType name:IdentifierName '=' __ cv:ConstValue ListSeparator? __ {
+    return new Const(name, ft, cv);
+  }
+
+ConstValue
+  = ConstList
+  / ConstMap
+  / StringLiteral
+  / NumberLiteral
+  / Identifier
+
+ConstList
+  = '[' __ values:(v:ConstValue __ ListSeparator? __ { return v} )* ']' __ {
+    return values
+  }
+
+ConstMap
+  = '{' __ (ConstValuePair)* '}' __
+
+ConstValuePair
+  = k:ConstValue __ ':' __ v:ConstValue __ ListSeparator?
+
+Struct
+  = 'struct' __ name:IdentifierName xsdAll? __ '{' __ fs:Field* __ '}' __ ta:TypeAnnotations? {
+    return new Struct(name, fs, ta);
+  }
+
+Union
+  = UnionToken name:IdentifierName xsdAll? __ '{' __ fs:Field* __ '}' __ {
+    return new Union(name, fs);
+  }
+
+xsdAll
+  = 'xsd_all' __
+
+xsdOptional
+  = 'xsd_optional' __
+
+xsdNillable
+  = 'xsd_nillable' __
+
+xsdAttributes
+  = 'xsd_attributes' __ '{' __ Field* __ '}' __
+
+Exception
+  = 'exception' __ name:IdentifierName '{' __ fs:Field* __ '}' __ ta:TypeAnnotations? __ {
+    return new Exception(name, fs, ta);
+  }
+
+Service
+  = 'service' __ name:IdentifierName extends? '{' __ fns:function* __ '}' __ ta:TypeAnnotations? {
+    return new Service(name, fns, ta);
+  }
+
+extends
+  = 'extends' __ IdentifierName
+
+function
+  = __ oneway? ft:FunctionType name:IdentifierName '(' __ fs:Field* __ ')' __ ts:throwz? ta:TypeAnnotations? ListSeparator? _ {
+    return new FunctionDescription(name, fs, ft, ts, ta);
+  }
+
+oneway
+  = 'oneway' __
+
+throwz
+  = 'throws' __ '(' __ fs:Field* __ ')' __ {
+    return new Throws(fs);
+  }
+
+Field
+  = _ id:FieldIdentifier? req:FieldRequiredness? ft:FieldType rec:Recursive? name:IdentifierName fv:FieldValue?
+    XsdFieldOptions? ta:TypeAnnotations? ListSeparator? {
+      return new Field(name, ft, id, req, fv, ta);
+    }
+
+Recursive
+  = '&'? __ {
+    return true;
+  } / {
+    return false;
+  }
+
+FieldIdentifier
+  = id:IntConstant ':' _ { return id.value; }
+
+FieldRequiredness
+  = 'required' __ { return 'required'; }
+  / 'optional' __ { return 'optional'; }
+
+FieldValue
+  = '=' __ cv:ConstValue __ { return cv; }
+
+FunctionType
+  = 'void' __ { return 'void'; }
+  / FieldType
+
+FieldType
+  = BaseType
+  / ContainerType
+  / Identifier
+
+XsdFieldOptions
+  = xsdOptional? xsdNillable? xsdAttributes?
+
+BaseType
+  = t:BaseTypeName __ ta:TypeAnnotations? {
+    return new BaseType(t, ta);
+  }
+
+BaseTypeName
+  = 'bool'
+  / 'byte'
+  / 'i16'
+  / 'i32'
+  / 'i64'
+  / 'double'
+  / 'string'
+  / 'binary'
+  / 'slist'
+
+ContainerType
+  = MapType
+  / SetType
+  / ListType
+
+MapType
+  = 'map' __ cppType? '<' __ ft1:FieldType __ ',' __ ft2:FieldType __ '>'
+    __ ta:TypeAnnotations?
+  {
+    return new MapType(ft1, ft2);
+  }
+
+SetType
+  = 'set' __ cppType? '<' __ ft:FieldType __ '>' __ ta:TypeAnnotations? {
+    return new SetType(ft);
+  }
+
+// It's weird, and probably an error, but the original thrift yacc
+// grammar puts cppType after the angle brackets for lists, but before
+// for sets and maps. The cpp_type isn't actually used anyway, so this
+// probably doesn't actually matter.
+
+ListType
+  = 'list' __ '<' __ ft:FieldType __ '>' __ ta:TypeAnnotations? cppType? {
+    return new ListType(ft);
+  }
+
+cppType
+  = 'cpp_type' __ i:Literal
+
+TypeAnnotations
+  = '(' __ entries:TypeAnnotation* __ ')' __ {
+    var annotations = {};
+    for (var index = 0; index < entries.length; index++) {
+      annotations[entries[index].name] = entries[index].value;
+    }
+    return annotations;
+  }
+
+TypeAnnotation
+  = name:IdentifierName v:('=' __ l:Literal { return l })? ListSeparator? {
+    return new TypeAnnotation(name, v);
+  }
+
+IntConstant
+  = HexIntegerLiteral
+  / SignedInteger
+
+word
+  = w:[a-zA-Z0-9_\.]+
+
+Identifier
+  = name:IdentifierName __ { return new Identifier(name); }
+
+IdentifierName 'identifier'
+  = !ReservedWord first:IdentifierStart rest:IdentifierPart* __ {
+      return first + rest.join('');
+    }
+
+IdentifierStart
+  = UnicodeLetter
+  / '_'
+
+IdentifierPart
+  = IdentifierStart
+  / UnicodeCombiningMark
+  / UnicodeDigit
+  / UnicodeConnectorPunctuation
+  / '\u200C'
+  / '\u200D'
+  / '.'
+
+UnicodeLetter
+  = Lu
+  / Ll
+  / Lt
+  / Lm
+  / Lo
+  / Nl
+
+UnicodeCombiningMark
+  = Mn
+  / Mc
+
+UnicodeDigit
+  = Nd
+
+UnicodeConnectorPunctuation
+  = Pc
+
+Letter
+  = [a-zA-Z]
+
+STIdentifierName
+  = !container_type_tokens word /* ('a'..'z' | 'A'..'Z' | '-')
+    ('.' | 'a'..'z' | 'A'..'Z' | '_' | '0'..'9' | '-')* */
+
+Literal
+  = '"' l:[^"]* '"' __ { return l.join('') }
+  / "'" l:[^']* "'" __ { return l.join('') }
+
+// Mandatory whitespace
+__
+  = (WhiteSpace / LineTerminatorSequence / Comment)*
+
+// Optional whitespace
+_
+  = (WhiteSpace / MultiLineCommentNoLineTerminator)*
+
+container_type_tokens
+  = ( 'map' / 'set' / 'list') ![A-Za-z_]
+
+SourceCharacter
+  = .
+
+WhiteSpace 'whitespace'
+  = '\t'
+  / '\v'
+  / '\f'
+  / ' '
+  / '\u00A0'
+  / '\uFEFF'
+  / Zs
+
+LineTerminator
+  = [\n\r\u2028\u2029]
+
+LineTerminatorSequence 'end of line'
+  = '\n'
+  / '\r\n'
+  / '\r'
+  / '\u2028'
+  / '\u2029'
+
+Comment 'comment'
+  = MultiLineComment
+  / SingleLineComment
+  / UnixComment
+
+MultiLineComment
+  = '/*' comment:(!'*/' c:SourceCharacter { return c; })* '*/' {
+    return new Comment(comment);
+  }
+
+MultiLineCommentNoLineTerminator
+  = '/*' (!('*/' / LineTerminator) SourceCharacter)* '*/'
+
+SingleLineComment
+  = '//' comment:(!LineTerminator sc:SourceCharacter { return sc; })* {
+    return new Comment(comment);
+  }
+
+UnixComment
+  = '#' comment:(!LineTerminator sc:SourceCharacter { return sc; })* {
+    return new Comment(comment);
+  }
+
+StringLiteral 'string'
+  = '"' chars:DoubleStringCharacter* '"' {
+      return new Literal(chars.join(''));
+    }
+  / "'" chars:SingleStringCharacter* "'" {
+      return new Literal(chars.join(''));
+    }
+
+DoubleStringCharacter
+  = !('"' / '\\' / LineTerminator) SourceCharacter { return text(); }
+  / '\\' sequence:EscapeSequence { return sequence; }
+  / LineContinuation
+
+SingleStringCharacter
+  = !("'" / '\\' / LineTerminator) SourceCharacter { return text(); }
+  / '\\' sequence:EscapeSequence { return sequence; }
+  / LineContinuation
+
+LineContinuation
+  = '\\' LineTerminatorSequence { return ''; }
+
+EscapeSequence
+  = CharacterEscapeSequence
+  / '0' !DecimalDigit { return '\0'; }
+  / HexEscapeSequence
+  / UnicodeEscapeSequence
+
+CharacterEscapeSequence
+  = SingleEscapeCharacter
+  / NonEscapeCharacter
+
+SingleEscapeCharacter
+  = "'"
+  / '"'
+  / '\\'
+  / 'b'  { return '\b';   }
+  / 'f'  { return '\f';   }
+  / 'n'  { return '\n';   }
+  / 'r'  { return '\r';   }
+  / 't'  { return '\t';   }
+  / 'v'  { return '\x0B'; }   // IE does not recognize '\v'.
+
+NonEscapeCharacter
+  = !(EscapeCharacter / LineTerminator) SourceCharacter { return text(); }
+
+EscapeCharacter
+  = SingleEscapeCharacter
+  / DecimalDigit
+  / 'x'
+  / 'u'
+
+HexEscapeSequence
+  = 'x' digits:$(HexDigit HexDigit) {
+      return String.fromCharCode(parseInt(digits, 16));
+    }
+
+UnicodeEscapeSequence
+  = 'u' digits:$(HexDigit HexDigit HexDigit HexDigit) {
+      return String.fromCharCode(parseInt(digits, 16));
+    }
+
+HexIntegerLiteral 'hex literal'
+  = '0x'i digits:$HexDigit+ {
+      return new Literal(parseInt(digits, 16));
+    }
+
+HexDigit
+  = [0-9a-f]i
+
+NumberLiteral 'number'
+  = HexIntegerLiteral
+  / [+-]? DecimalLiteral
+  / SignedInteger
+
+DecimalLiteral 'decimal literal'
+  = DecimalDigit+ ('.' DecimalDigit+)? ExponentPart? {
+    return new Literal(parseFloat(text()));
+  }
+  / '.' DecimalDigit+ ExponentPart? {
+    return new Literal(parseFloat(text()));
+  }
+  / DecimalDigit+ ExponentPart? {
+    return new Literal(parseFloat(text()));
+  }
+
+ExponentPart
+  = ExponentIndicator SignedInteger
+
+ExponentIndicator
+  = 'e'i
+
+DecimalIntegerLiteral
+  = DecimalDigit+
+
+DecimalDigit
+  = [0-9]
+
+NonZeroDigit
+  = [1-9]
+
+SignedInteger
+  = [+-]? DecimalDigit+ {
+    return new Literal(parseFloat(text(), 10));
+  }
+
+
+/* Tokens */
+
+IncludeToken     = 'include'      !IdentifierPart __
+CppIncludeToken  = 'cpp_include'  !IdentifierPart __
+NamespaceToken   = 'namespace'    !IdentifierPart __
+TypedefToken     = 'typedef'      !IdentifierPart __
+EnumToken        = 'enum'         !IdentifierPart __
+SenumToken       = 'senum'        !IdentifierPart __
+ConstToken       = 'const'        !IdentifierPart __
+VoidToken        = 'void'         !IdentifierPart __
+SetToken         = 'set'          !IdentifierPart __
+MapToken         = 'map'          !IdentifierPart __
+ListToken        = 'list'         !IdentifierPart __
+UnionToken       = 'union'        !IdentifierPart __
+
+ReservedWord
+  = VoidToken
+  / SetToken
+  / MapToken
+  / ListToken
+
+/*
+ * Unicode Character Categories
+ *
+ * Extracted from the following Unicode Character Database file:
+ *
+ *   http://www.unicode.org/Public/6.3.0/ucd/extracted/DerivedGeneralCategory.txt
+ *
+ * Unix magic used:
+ *
+ *   grep "; $CATEGORY" DerivedGeneralCategory.txt |   # Filter characters
+ *     cut -f1 -d " " |                                # Extract code points
+ *     grep -v '[0-9a-fA-F]\{5\}' |                    # Exclude non-BMP characters
+ *     sed -e 's/\.\./-/' |                            # Adjust formatting
+ *     sed -e 's/\([0-9a-fA-F]\{4\}\)/\\u\1/g' |       # Adjust formatting
+ *     tr -d '\n'                                      # Join lines
+ *
+ * ECMA-262 allows using Unicode 3.0 or later, version 6.3.0 was the latest one
+ * at the time of writing.
+ *
+ * Non-BMP characters are completely ignored to avoid surrogate pair handling
+ * (detecting surrogate pairs isn't possible with a simple character class and
+ * other methods would degrade performance). I don't consider it a big deal as
+ * even parsers in JavaScript engines of common browsers seem to ignore them.
+ */
+
+// Letter, Lowercase
+Ll = [\u0061-\u007A\u00B5\u00DF-\u00F6\u00F8-\u00FF\u0101\u0103\u0105\u0107\u0109\u010B\u010D\u010F\u0111\u0113\u0115\u0117\u0119\u011B\u011D\u011F\u0121\u0123\u0125\u0127\u0129\u012B\u012D\u012F\u0131\u0133\u0135\u0137-\u0138\u013A\u013C\u013E\u0140\u0142\u0144\u0146\u0148-\u0149\u014B\u014D\u014F\u0151\u0153\u0155\u0157\u0159\u015B\u015D\u015F\u0161\u0163\u0165\u0167\u0169\u016B\u016D\u016F\u0171\u0173\u0175\u0177\u017A\u017C\u017E-\u0180\u0183\u0185\u0188\u018C-\u018D\u0192\u0195\u0199-\u019B\u019E\u01A1\u01A3\u01A5\u01A8\u01AA-\u01AB\u01AD\u01B0\u01B4\u01B6\u01B9-\u01BA\u01BD-\u01BF\u01C6\u01C9\u01CC\u01CE\u01D0\u01D2\u01D4\u01D6\u01D8\u01DA\u01DC-\u01DD\u01DF\u01E1\u01E3\u01E5\u01E7\u01E9\u01EB\u01ED\u01EF-\u01F0\u01F3\u01F5\u01F9\u01FB\u01FD\u01FF\u0201\u0203\u0205\u0207\u0209\u020B\u020D\u020F\u0211\u0213\u0215\u0217\u0219\u021B\u021D\u021F\u0221\u0223\u0225\u0227\u0229\u022B\u022D\u022F\u0231\u0233-\u0239\u023C\u023F-\u0240\u0242\u0247\u0249\u024B\u024D\u024F-\u0293\u0295-\u02AF\u0371\u0373\u0377\u037B-\u037D\u0390\u03AC-\u03CE\u03D0-\u03D1\u03D5-\u03D7\u03D9\u03DB\u03DD\u03DF\u03E1\u03E3\u03E5\u03E7\u03E9\u03EB\u03ED\u03EF-\u03F3\u03F5\u03F8\u03FB-\u03FC\u0430-\u045F\u0461\u0463\u0465\u0467\u0469\u046B\u046D\u046F\u0471\u0473\u0475\u0477\u0479\u047B\u047D\u047F\u0481\u048B\u048D\u048F\u0491\u0493\u0495\u0497\u0499\u049B\u049D\u049F\u04A1\u04A3\u04A5\u04A7\u04A9\u04AB\u04AD\u04AF\u04B1\u04B3\u04B5\u04B7\u04B9\u04BB\u04BD\u04BF\u04C2\u04C4\u04C6\u04C8\u04CA\u04CC\u04CE-\u04CF\u04D1\u04D3\u04D5\u04D7\u04D9\u04DB\u04DD\u04DF\u04E1\u04E3\u04E5\u04E7\u04E9\u04EB\u04ED\u04EF\u04F1\u04F3\u04F5\u04F7\u04F9\u04FB\u04FD\u04FF\u0501\u0503\u0505\u0507\u0509\u050B\u050D\u050F\u0511\u0513\u0515\u0517\u0519\u051B\u051D\u051F\u0521\u0523\u0525\u0527\u0561-\u0587\u1D00-\u1D2B\u1D6B-\u1D77\u1D79-\u1D9A\u1E01\u1E03\u1E05\u1E07\u1E09\u1E0B\u1E0D\u1E0F\u1E11\u1E13\u1E15\u1E17\u1E19\u1E1B\u1E1D\u1E1F\u1E21\u1E23\u1E25\u1E27\u1E29\u1E2B\u1E2D\u1E2F\u1E31\u1E33\u1E35\u1E37\u1E39\u1E3B\u1E3D\u1E3F\u1E41\u1E43\u1E45\u1E47\u1E49\u1E4B\u1E4D\u1E4F\u1E51\u1E53\u1E55\u1E57\u1E59\u1E5B\u1E5D\u1E5F\u1E61\u1E63\u1E65\u1E67\u1E69\u1E6B\u1E6D\u1E6F\u1E71\u1E73\u1E75\u1E77\u1E79\u1E7B\u1E7D\u1E7F\u1E81\u1E83\u1E85\u1E87\u1E89\u1E8B\u1E8D\u1E8F\u1E91\u1E93\u1E95-\u1E9D\u1E9F\u1EA1\u1EA3\u1EA5\u1EA7\u1EA9\u1EAB\u1EAD\u1EAF\u1EB1\u1EB3\u1EB5\u1EB7\u1EB9\u1EBB\u1EBD\u1EBF\u1EC1\u1EC3\u1EC5\u1EC7\u1EC9\u1ECB\u1ECD\u1ECF\u1ED1\u1ED3\u1ED5\u1ED7\u1ED9\u1EDB\u1EDD\u1EDF\u1EE1\u1EE3\u1EE5\u1EE7\u1EE9\u1EEB\u1EED\u1EEF\u1EF1\u1EF3\u1EF5\u1EF7\u1EF9\u1EFB\u1EFD\u1EFF-\u1F07\u1F10-\u1F15\u1F20-\u1F27\u1F30-\u1F37\u1F40-\u1F45\u1F50-\u1F57\u1F60-\u1F67\u1F70-\u1F7D\u1F80-\u1F87\u1F90-\u1F97\u1FA0-\u1FA7\u1FB0-\u1FB4\u1FB6-\u1FB7\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FC7\u1FD0-\u1FD3\u1FD6-\u1FD7\u1FE0-\u1FE7\u1FF2-\u1FF4\u1FF6-\u1FF7\u210A\u210E-\u210F\u2113\u212F\u2134\u2139\u213C-\u213D\u2146-\u2149\u214E\u2184\u2C30-\u2C5E\u2C61\u2C65-\u2C66\u2C68\u2C6A\u2C6C\u2C71\u2C73-\u2C74\u2C76-\u2C7B\u2C81\u2C83\u2C85\u2C87\u2C89\u2C8B\u2C8D\u2C8F\u2C91\u2C93\u2C95\u2C97\u2C99\u2C9B\u2C9D\u2C9F\u2CA1\u2CA3\u2CA5\u2CA7\u2CA9\u2CAB\u2CAD\u2CAF\u2CB1\u2CB3\u2CB5\u2CB7\u2CB9\u2CBB\u2CBD\u2CBF\u2CC1\u2CC3\u2CC5\u2CC7\u2CC9\u2CCB\u2CCD\u2CCF\u2CD1\u2CD3\u2CD5\u2CD7\u2CD9\u2CDB\u2CDD\u2CDF\u2CE1\u2CE3-\u2CE4\u2CEC\u2CEE\u2CF3\u2D00-\u2D25\u2D27\u2D2D\uA641\uA643\uA645\uA647\uA649\uA64B\uA64D\uA64F\uA651\uA653\uA655\uA657\uA659\uA65B\uA65D\uA65F\uA661\uA663\uA665\uA667\uA669\uA66B\uA66D\uA681\uA683\uA685\uA687\uA689\uA68B\uA68D\uA68F\uA691\uA693\uA695\uA697\uA723\uA725\uA727\uA729\uA72B\uA72D\uA72F-\uA731\uA733\uA735\uA737\uA739\uA73B\uA73D\uA73F\uA741\uA743\uA745\uA747\uA749\uA74B\uA74D\uA74F\uA751\uA753\uA755\uA757\uA759\uA75B\uA75D\uA75F\uA761\uA763\uA765\uA767\uA769\uA76B\uA76D\uA76F\uA771-\uA778\uA77A\uA77C\uA77F\uA781\uA783\uA785\uA787\uA78C\uA78E\uA791\uA793\uA7A1\uA7A3\uA7A5\uA7A7\uA7A9\uA7FA\uFB00-\uFB06\uFB13-\uFB17\uFF41-\uFF5A]
+
+// Letter, Modifier
+Lm = [\u02B0-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0374\u037A\u0559\u0640\u06E5-\u06E6\u07F4-\u07F5\u07FA\u081A\u0824\u0828\u0971\u0E46\u0EC6\u10FC\u17D7\u1843\u1AA7\u1C78-\u1C7D\u1D2C-\u1D6A\u1D78\u1D9B-\u1DBF\u2071\u207F\u2090-\u209C\u2C7C-\u2C7D\u2D6F\u2E2F\u3005\u3031-\u3035\u303B\u309D-\u309E\u30FC-\u30FE\uA015\uA4F8-\uA4FD\uA60C\uA67F\uA717-\uA71F\uA770\uA788\uA7F8-\uA7F9\uA9CF\uAA70\uAADD\uAAF3-\uAAF4\uFF70\uFF9E-\uFF9F]
+
+// Letter, Other
+Lo = [\u00AA\u00BA\u01BB\u01C0-\u01C3\u0294\u05D0-\u05EA\u05F0-\u05F2\u0620-\u063F\u0641-\u064A\u066E-\u066F\u0671-\u06D3\u06D5\u06EE-\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u0800-\u0815\u0840-\u0858\u08A0\u08A2-\u08AC\u0904-\u0939\u093D\u0950\u0958-\u0961\u0972-\u0977\u0979-\u097F\u0985-\u098C\u098F-\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC-\u09DD\u09DF-\u09E1\u09F0-\u09F1\u0A05-\u0A0A\u0A0F-\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32-\u0A33\u0A35-\u0A36\u0A38-\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2-\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0-\u0AE1\u0B05-\u0B0C\u0B0F-\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32-\u0B33\u0B35-\u0B39\u0B3D\u0B5C-\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99-\u0B9A\u0B9C\u0B9E-\u0B9F\u0BA3-\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C33\u0C35-\u0C39\u0C3D\u0C58-\u0C59\u0C60-\u0C61\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDE\u0CE0-\u0CE1\u0CF1-\u0CF2\u0D05-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D60-\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32-\u0E33\u0E40-\u0E45\u0E81-\u0E82\u0E84\u0E87-\u0E88\u0E8A\u0E8D\u0E94-\u0E97\u0E99-\u0E9F\u0EA1-\u0EA3\u0EA5\u0EA7\u0EAA-\u0EAB\u0EAD-\u0EB0\u0EB2-\u0EB3\u0EBD\u0EC0-\u0EC4\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065-\u1066\u106E-\u1070\u1075-\u1081\u108E\u10D0-\u10FA\u10FD-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u13A0-\u13F4\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u1700-\u170C\u170E-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17DC\u1820-\u1842\u1844-\u1877\u1880-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191C\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19C1-\u19C7\u1A00-\u1A16\u1A20-\u1A54\u1B05-\u1B33\u1B45-\u1B4B\u1B83-\u1BA0\u1BAE-\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C77\u1CE9-\u1CEC\u1CEE-\u1CF1\u1CF5-\u1CF6\u2135-\u2138\u2D30-\u2D67\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u3006\u303C\u3041-\u3096\u309F\u30A1-\u30FA\u30FF\u3105-\u312D\u3131-\u318E\u31A0-\u31BA\u31F0-\u31FF\u3400-\u4DB5\u4E00-\u9FCC\uA000-\uA014\uA016-\uA48C\uA4D0-\uA4F7\uA500-\uA60B\uA610-\uA61F\uA62A-\uA62B\uA66E\uA6A0-\uA6E5\uA7FB-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA6F\uAA71-\uAA76\uAA7A\uAA80-\uAAAF\uAAB1\uAAB5-\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADC\uAAE0-\uAAEA\uAAF2\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uABC0-\uABE2\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40-\uFB41\uFB43-\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF66-\uFF6F\uFF71-\uFF9D\uFFA0-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC]
+
+// Letter, Titlecase
+Lt = [\u01C5\u01C8\u01CB\u01F2\u1F88-\u1F8F\u1F98-\u1F9F\u1FA8-\u1FAF\u1FBC\u1FCC\u1FFC]
+
+// Letter, Uppercase
+Lu = [\u0041-\u005A\u00C0-\u00D6\u00D8-\u00DE\u0100\u0102\u0104\u0106\u0108\u010A\u010C\u010E\u0110\u0112\u0114\u0116\u0118\u011A\u011C\u011E\u0120\u0122\u0124\u0126\u0128\u012A\u012C\u012E\u0130\u0132\u0134\u0136\u0139\u013B\u013D\u013F\u0141\u0143\u0145\u0147\u014A\u014C\u014E\u0150\u0152\u0154\u0156\u0158\u015A\u015C\u015E\u0160\u0162\u0164\u0166\u0168\u016A\u016C\u016E\u0170\u0172\u0174\u0176\u0178-\u0179\u017B\u017D\u0181-\u0182\u0184\u0186-\u0187\u0189-\u018B\u018E-\u0191\u0193-\u0194\u0196-\u0198\u019C-\u019D\u019F-\u01A0\u01A2\u01A4\u01A6-\u01A7\u01A9\u01AC\u01AE-\u01AF\u01B1-\u01B3\u01B5\u01B7-\u01B8\u01BC\u01C4\u01C7\u01CA\u01CD\u01CF\u01D1\u01D3\u01D5\u01D7\u01D9\u01DB\u01DE\u01E0\u01E2\u01E4\u01E6\u01E8\u01EA\u01EC\u01EE\u01F1\u01F4\u01F6-\u01F8\u01FA\u01FC\u01FE\u0200\u0202\u0204\u0206\u0208\u020A\u020C\u020E\u0210\u0212\u0214\u0216\u0218\u021A\u021C\u021E\u0220\u0222\u0224\u0226\u0228\u022A\u022C\u022E\u0230\u0232\u023A-\u023B\u023D-\u023E\u0241\u0243-\u0246\u0248\u024A\u024C\u024E\u0370\u0372\u0376\u0386\u0388-\u038A\u038C\u038E-\u038F\u0391-\u03A1\u03A3-\u03AB\u03CF\u03D2-\u03D4\u03D8\u03DA\u03DC\u03DE\u03E0\u03E2\u03E4\u03E6\u03E8\u03EA\u03EC\u03EE\u03F4\u03F7\u03F9-\u03FA\u03FD-\u042F\u0460\u0462\u0464\u0466\u0468\u046A\u046C\u046E\u0470\u0472\u0474\u0476\u0478\u047A\u047C\u047E\u0480\u048A\u048C\u048E\u0490\u0492\u0494\u0496\u0498\u049A\u049C\u049E\u04A0\u04A2\u04A4\u04A6\u04A8\u04AA\u04AC\u04AE\u04B0\u04B2\u04B4\u04B6\u04B8\u04BA\u04BC\u04BE\u04C0-\u04C1\u04C3\u04C5\u04C7\u04C9\u04CB\u04CD\u04D0\u04D2\u04D4\u04D6\u04D8\u04DA\u04DC\u04DE\u04E0\u04E2\u04E4\u04E6\u04E8\u04EA\u04EC\u04EE\u04F0\u04F2\u04F4\u04F6\u04F8\u04FA\u04FC\u04FE\u0500\u0502\u0504\u0506\u0508\u050A\u050C\u050E\u0510\u0512\u0514\u0516\u0518\u051A\u051C\u051E\u0520\u0522\u0524\u0526\u0531-\u0556\u10A0-\u10C5\u10C7\u10CD\u1E00\u1E02\u1E04\u1E06\u1E08\u1E0A\u1E0C\u1E0E\u1E10\u1E12\u1E14\u1E16\u1E18\u1E1A\u1E1C\u1E1E\u1E20\u1E22\u1E24\u1E26\u1E28\u1E2A\u1E2C\u1E2E\u1E30\u1E32\u1E34\u1E36\u1E38\u1E3A\u1E3C\u1E3E\u1E40\u1E42\u1E44\u1E46\u1E48\u1E4A\u1E4C\u1E4E\u1E50\u1E52\u1E54\u1E56\u1E58\u1E5A\u1E5C\u1E5E\u1E60\u1E62\u1E64\u1E66\u1E68\u1E6A\u1E6C\u1E6E\u1E70\u1E72\u1E74\u1E76\u1E78\u1E7A\u1E7C\u1E7E\u1E80\u1E82\u1E84\u1E86\u1E88\u1E8A\u1E8C\u1E8E\u1E90\u1E92\u1E94\u1E9E\u1EA0\u1EA2\u1EA4\u1EA6\u1EA8\u1EAA\u1EAC\u1EAE\u1EB0\u1EB2\u1EB4\u1EB6\u1EB8\u1EBA\u1EBC\u1EBE\u1EC0\u1EC2\u1EC4\u1EC6\u1EC8\u1ECA\u1ECC\u1ECE\u1ED0\u1ED2\u1ED4\u1ED6\u1ED8\u1EDA\u1EDC\u1EDE\u1EE0\u1EE2\u1EE4\u1EE6\u1EE8\u1EEA\u1EEC\u1EEE\u1EF0\u1EF2\u1EF4\u1EF6\u1EF8\u1EFA\u1EFC\u1EFE\u1F08-\u1F0F\u1F18-\u1F1D\u1F28-\u1F2F\u1F38-\u1F3F\u1F48-\u1F4D\u1F59\u1F5B\u1F5D\u1F5F\u1F68-\u1F6F\u1FB8-\u1FBB\u1FC8-\u1FCB\u1FD8-\u1FDB\u1FE8-\u1FEC\u1FF8-\u1FFB\u2102\u2107\u210B-\u210D\u2110-\u2112\u2115\u2119-\u211D\u2124\u2126\u2128\u212A-\u212D\u2130-\u2133\u213E-\u213F\u2145\u2183\u2C00-\u2C2E\u2C60\u2C62-\u2C64\u2C67\u2C69\u2C6B\u2C6D-\u2C70\u2C72\u2C75\u2C7E-\u2C80\u2C82\u2C84\u2C86\u2C88\u2C8A\u2C8C\u2C8E\u2C90\u2C92\u2C94\u2C96\u2C98\u2C9A\u2C9C\u2C9E\u2CA0\u2CA2\u2CA4\u2CA6\u2CA8\u2CAA\u2CAC\u2CAE\u2CB0\u2CB2\u2CB4\u2CB6\u2CB8\u2CBA\u2CBC\u2CBE\u2CC0\u2CC2\u2CC4\u2CC6\u2CC8\u2CCA\u2CCC\u2CCE\u2CD0\u2CD2\u2CD4\u2CD6\u2CD8\u2CDA\u2CDC\u2CDE\u2CE0\u2CE2\u2CEB\u2CED\u2CF2\uA640\uA642\uA644\uA646\uA648\uA64A\uA64C\uA64E\uA650\uA652\uA654\uA656\uA658\uA65A\uA65C\uA65E\uA660\uA662\uA664\uA666\uA668\uA66A\uA66C\uA680\uA682\uA684\uA686\uA688\uA68A\uA68C\uA68E\uA690\uA692\uA694\uA696\uA722\uA724\uA726\uA728\uA72A\uA72C\uA72E\uA732\uA734\uA736\uA738\uA73A\uA73C\uA73E\uA740\uA742\uA744\uA746\uA748\uA74A\uA74C\uA74E\uA750\uA752\uA754\uA756\uA758\uA75A\uA75C\uA75E\uA760\uA762\uA764\uA766\uA768\uA76A\uA76C\uA76E\uA779\uA77B\uA77D-\uA77E\uA780\uA782\uA784\uA786\uA78B\uA78D\uA790\uA792\uA7A0\uA7A2\uA7A4\uA7A6\uA7A8\uA7AA\uFF21-\uFF3A]
+
+// Mark, Spacing Combining
+Mc = [\u0903\u093B\u093E-\u0940\u0949-\u094C\u094E-\u094F\u0982-\u0983\u09BE-\u09C0\u09C7-\u09C8\u09CB-\u09CC\u09D7\u0A03\u0A3E-\u0A40\u0A83\u0ABE-\u0AC0\u0AC9\u0ACB-\u0ACC\u0B02-\u0B03\u0B3E\u0B40\u0B47-\u0B48\u0B4B-\u0B4C\u0B57\u0BBE-\u0BBF\u0BC1-\u0BC2\u0BC6-\u0BC8\u0BCA-\u0BCC\u0BD7\u0C01-\u0C03\u0C41-\u0C44\u0C82-\u0C83\u0CBE\u0CC0-\u0CC4\u0CC7-\u0CC8\u0CCA-\u0CCB\u0CD5-\u0CD6\u0D02-\u0D03\u0D3E-\u0D40\u0D46-\u0D48\u0D4A-\u0D4C\u0D57\u0D82-\u0D83\u0DCF-\u0DD1\u0DD8-\u0DDF\u0DF2-\u0DF3\u0F3E-\u0F3F\u0F7F\u102B-\u102C\u1031\u1038\u103B-\u103C\u1056-\u1057\u1062-\u1064\u1067-\u106D\u1083-\u1084\u1087-\u108C\u108F\u109A-\u109C\u17B6\u17BE-\u17C5\u17C7-\u17C8\u1923-\u1926\u1929-\u192B\u1930-\u1931\u1933-\u1938\u19B0-\u19C0\u19C8-\u19C9\u1A19-\u1A1A\u1A55\u1A57\u1A61\u1A63-\u1A64\u1A6D-\u1A72\u1B04\u1B35\u1B3B\u1B3D-\u1B41\u1B43-\u1B44\u1B82\u1BA1\u1BA6-\u1BA7\u1BAA\u1BAC-\u1BAD\u1BE7\u1BEA-\u1BEC\u1BEE\u1BF2-\u1BF3\u1C24-\u1C2B\u1C34-\u1C35\u1CE1\u1CF2-\u1CF3\u302E-\u302F\uA823-\uA824\uA827\uA880-\uA881\uA8B4-\uA8C3\uA952-\uA953\uA983\uA9B4-\uA9B5\uA9BA-\uA9BB\uA9BD-\uA9C0\uAA2F-\uAA30\uAA33-\uAA34\uAA4D\uAA7B\uAAEB\uAAEE-\uAAEF\uAAF5\uABE3-\uABE4\uABE6-\uABE7\uABE9-\uABEA\uABEC]
+
+// Mark, Nonspacing
+Mn = [\u0300-\u036F\u0483-\u0487\u0591-\u05BD\u05BF\u05C1-\u05C2\u05C4-\u05C5\u05C7\u0610-\u061A\u064B-\u065F\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7-\u06E8\u06EA-\u06ED\u0711\u0730-\u074A\u07A6-\u07B0\u07EB-\u07F3\u0816-\u0819\u081B-\u0823\u0825-\u0827\u0829-\u082D\u0859-\u085B\u08E4-\u08FE\u0900-\u0902\u093A\u093C\u0941-\u0948\u094D\u0951-\u0957\u0962-\u0963\u0981\u09BC\u09C1-\u09C4\u09CD\u09E2-\u09E3\u0A01-\u0A02\u0A3C\u0A41-\u0A42\u0A47-\u0A48\u0A4B-\u0A4D\u0A51\u0A70-\u0A71\u0A75\u0A81-\u0A82\u0ABC\u0AC1-\u0AC5\u0AC7-\u0AC8\u0ACD\u0AE2-\u0AE3\u0B01\u0B3C\u0B3F\u0B41-\u0B44\u0B4D\u0B56\u0B62-\u0B63\u0B82\u0BC0\u0BCD\u0C3E-\u0C40\u0C46-\u0C48\u0C4A-\u0C4D\u0C55-\u0C56\u0C62-\u0C63\u0CBC\u0CBF\u0CC6\u0CCC-\u0CCD\u0CE2-\u0CE3\u0D41-\u0D44\u0D4D\u0D62-\u0D63\u0DCA\u0DD2-\u0DD4\u0DD6\u0E31\u0E34-\u0E3A\u0E47-\u0E4E\u0EB1\u0EB4-\u0EB9\u0EBB-\u0EBC\u0EC8-\u0ECD\u0F18-\u0F19\u0F35\u0F37\u0F39\u0F71-\u0F7E\u0F80-\u0F84\u0F86-\u0F87\u0F8D-\u0F97\u0F99-\u0FBC\u0FC6\u102D-\u1030\u1032-\u1037\u1039-\u103A\u103D-\u103E\u1058-\u1059\u105E-\u1060\u1071-\u1074\u1082\u1085-\u1086\u108D\u109D\u135D-\u135F\u1712-\u1714\u1732-\u1734\u1752-\u1753\u1772-\u1773\u17B4-\u17B5\u17B7-\u17BD\u17C6\u17C9-\u17D3\u17DD\u180B-\u180D\u18A9\u1920-\u1922\u1927-\u1928\u1932\u1939-\u193B\u1A17-\u1A18\u1A1B\u1A56\u1A58-\u1A5E\u1A60\u1A62\u1A65-\u1A6C\u1A73-\u1A7C\u1A7F\u1B00-\u1B03\u1B34\u1B36-\u1B3A\u1B3C\u1B42\u1B6B-\u1B73\u1B80-\u1B81\u1BA2-\u1BA5\u1BA8-\u1BA9\u1BAB\u1BE6\u1BE8-\u1BE9\u1BED\u1BEF-\u1BF1\u1C2C-\u1C33\u1C36-\u1C37\u1CD0-\u1CD2\u1CD4-\u1CE0\u1CE2-\u1CE8\u1CED\u1CF4\u1DC0-\u1DE6\u1DFC-\u1DFF\u20D0-\u20DC\u20E1\u20E5-\u20F0\u2CEF-\u2CF1\u2D7F\u2DE0-\u2DFF\u302A-\u302D\u3099-\u309A\uA66F\uA674-\uA67D\uA69F\uA6F0-\uA6F1\uA802\uA806\uA80B\uA825-\uA826\uA8C4\uA8E0-\uA8F1\uA926-\uA92D\uA947-\uA951\uA980-\uA982\uA9B3\uA9B6-\uA9B9\uA9BC\uAA29-\uAA2E\uAA31-\uAA32\uAA35-\uAA36\uAA43\uAA4C\uAAB0\uAAB2-\uAAB4\uAAB7-\uAAB8\uAABE-\uAABF\uAAC1\uAAEC-\uAAED\uAAF6\uABE5\uABE8\uABED\uFB1E\uFE00-\uFE0F\uFE20-\uFE26]
+
+// Number, Decimal Digit
+Nd = [\u0030-\u0039\u0660-\u0669\u06F0-\u06F9\u07C0-\u07C9\u0966-\u096F\u09E6-\u09EF\u0A66-\u0A6F\u0AE6-\u0AEF\u0B66-\u0B6F\u0BE6-\u0BEF\u0C66-\u0C6F\u0CE6-\u0CEF\u0D66-\u0D6F\u0E50-\u0E59\u0ED0-\u0ED9\u0F20-\u0F29\u1040-\u1049\u1090-\u1099\u17E0-\u17E9\u1810-\u1819\u1946-\u194F\u19D0-\u19D9\u1A80-\u1A89\u1A90-\u1A99\u1B50-\u1B59\u1BB0-\u1BB9\u1C40-\u1C49\u1C50-\u1C59\uA620-\uA629\uA8D0-\uA8D9\uA900-\uA909\uA9D0-\uA9D9\uAA50-\uAA59\uABF0-\uABF9\uFF10-\uFF19]
+
+// Number, Letter
+Nl = [\u16EE-\u16F0\u2160-\u2182\u2185-\u2188\u3007\u3021-\u3029\u3038-\u303A\uA6E6-\uA6EF]
+
+// Punctuation, Connector
+Pc = [\u005F\u203F-\u2040\u2054\uFE33-\uFE34\uFE4D-\uFE4F\uFF3F]
+
+// Separator, Space
+Zs = [\u0020\u00A0\u1680\u2000-\u200A\u202F\u205F\u3000]


### PR DESCRIPTION
Note that some debt is paid off from the original in Thriftify,
particularly the abbreviated property names, collapsed identifier nodes
(just a string now), and all node types.

r @jcorbin @malandrew 

Next up will be a StructSpec that contains a SpecRW based on its Thrift IDL description.