### PR TITLE
Borg thriftify

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
     "rules": {
         "max-len": [1, 120],
+        "max-statements": [1, 30],
         "curly": 0
     }
 }

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,6 +6,35 @@ versions of this module to newer versions.
 This document only describes what breaks and how to update your
 code.
 
-<!--
-# Upgrading from v1 to v2
--->
+# Upgrading from thriftify to thriftrw
+
+Loading a spec and using it to read and write types.
+
+```js
+var source = fs.readFileSync('my.thrift', 'ascii');
+
+// Before:
+var thriftify = require('thriftify');
+var spec = thriftify.parseSpec(source);
+
+// After:
+var Spec = require('thriftrw').Spec;
+var spec = new Spec({source: source});
+
+var args = spec.getType('MyService::myFunction_args');
+var struct = args.fromBuffer(buffer);
+var buffer = args.toBuffer(struct)
+```
+
+Reading and writing a type
+
+```js
+// Before:
+var buffer = thriftify.toBuffer(struct, spec, 'MyStruct')
+var struct = thriftify.fromBuffer(buffer, spec, 'MyStruct')
+
+// After:
+var MyStruct = spec.getType('MyStruct');
+var buffer = MyStruct.toBuffer(struct);
+var struct = MyStruct.fromBuffer(buffer);
+```

--- a/binary.js
+++ b/binary.js
@@ -28,6 +28,7 @@ var BinaryRW = new bufrw.VariableBuffer(bufrw.Int32BE);
 function BinarySpec() { }
 
 BinarySpec.prototype.rw = BinaryRW;
+BinarySpec.prototype.name = 'binary';
 BinarySpec.prototype.typeid = TYPE.STRING;
 
 module.exports.BinaryRW = BinaryRW;

--- a/boolean.js
+++ b/boolean.js
@@ -51,6 +51,7 @@ function writeTBooleanInto(bool, buffer, offset) {
 
 function BooleanSpec() { }
 BooleanSpec.prototype.rw = BooleanRW;
+BooleanSpec.prototype.name = 'boolean';
 BooleanSpec.prototype.typeid = TYPE.BOOL;
 
 module.exports.BooleanRW = BooleanRW;

--- a/byte.js
+++ b/byte.js
@@ -28,6 +28,7 @@ var ByteRW = bufrw.Int8;
 function ByteSpec() { }
 
 ByteSpec.prototype.rw = ByteRW;
+ByteSpec.prototype.name = 'byte';
 ByteSpec.prototype.typeid = TYPE.BYTE;
 
 module.exports.ByteRW = ByteRW;

--- a/const.js
+++ b/const.js
@@ -20,27 +20,21 @@
 
 'use strict';
 
-require('./binary');
-require('./boolean');
-require('./byte');
-require('./double');
-require('./i16');
-require('./i32');
-require('./i64');
-require('./specmap-entries');
-require('./thrift-idl');
-require('./specmap-obj');
-require('./string');
-require('./tlist');
-require('./tmap');
-require('./tstruct');
-require('./void');
-require('./skip');
-require('./struct');
-require('./struct-skip');
-require('./exception');
-require('./service');
-require('./spec');
-require('./list');
-require('./set');
-require('./const');
+function ConstSpec(def) {
+    var self = this;
+    self.name = def.id.name;
+    self.valueDefinition = def.value;
+    self.defined = false;
+    self.value = null;
+}
+
+ConstSpec.prototype.link = function link(spec) {
+    var self = this;
+    if (!self.defined) {
+        self.defined = true;
+        self.value = spec.resolveValue(self.valueDefinition);
+    }
+    return self.value;
+};
+
+module.exports.ConstSpec = ConstSpec;

--- a/double.js
+++ b/double.js
@@ -28,6 +28,7 @@ var DoubleRW = bufrw.DoubleBE;
 function DoubleSpec() { }
 
 DoubleSpec.prototype.rw = DoubleRW;
+DoubleSpec.prototype.name = 'double';
 DoubleSpec.prototype.typeid = TYPE.DOUBLE;
 
 module.exports.DoubleRW = DoubleRW;

--- a/enum.js
+++ b/enum.js
@@ -1,0 +1,133 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var assert = require('assert');
+var bufrw = require('bufrw');
+var TYPE = require('./TYPE');
+var errors = require('./errors');
+var ConstSpec = require('./const').ConstSpec;
+
+var LengthResult = bufrw.LengthResult;
+var WriteResult = bufrw.WriteResult;
+var ReadResult = bufrw.ReadResult;
+
+function EnumSpec() {
+    var self = this;
+    self.namesToValues = Object.create(null);
+    self.valuesToNames = Object.create(null);
+    self.rw = new EnumRW(self);
+}
+
+EnumSpec.prototype.typeid = TYPE.I32;
+
+EnumSpec.prototype.compile = function compile(def, spec) {
+    var self = this;
+
+    self.name = def.id.name;
+
+    var value = 0;
+    var enumDefs = def.definitions;
+    for (var index = 0; index < enumDefs.length; index++) {
+        var enumDef = enumDefs[index];
+        var name = enumDef.id.name;
+        var valueDef = enumDef.value;
+        if (valueDef && valueDef.value !== undefined) {
+            value = valueDef.value;
+        }
+
+        assert(self.namesToValues[name] === undefined,
+            'duplicate name in enum ' + self.name +
+            ' at ' + def.id.line + ':' + def.id.column);
+        assert(value <= 0x7fffffff,
+            'overflow in value in enum ' + self.name +
+            ' at ' + def.id.line + ':' + def.id.column);
+
+        var fullName = self.name + '.' + name;
+        spec.claim(fullName, enumDef.id);
+        spec.constSpecs[fullName] = new ConstSpec({
+            id: {name: name},
+            value: {type: 'Literal', value: name}
+        });
+        self.namesToValues[name] = value;
+        self.valuesToNames[value] = name;
+        value++;
+    }
+};
+
+EnumSpec.prototype.link = function link(spec) {
+    var self = this;
+    return self;
+};
+
+function EnumRW(spec) {
+    var self = this;
+    self.spec = spec;
+}
+
+EnumRW.prototype.lengthResult = new LengthResult(null, bufrw.Int32BE.width);
+
+EnumRW.prototype.byteLength = function byteLength() {
+    var self = this;
+    return self.lengthResult;
+};
+
+EnumRW.prototype.writeInto = function writeInto(name, buffer, offset) {
+    var self = this;
+    if (typeof name !== 'string') {
+        return new WriteResult(errors.InvalidEnumerationTypeError({
+            enumName: self.spec.name,
+            name: name,
+            nameType: typeof name
+        }));
+    }
+    var value = self.spec.namesToValues[name];
+    // istanbul ignore if
+    if (value === undefined) {
+        return new WriteResult(errors.InvalidEnumerationNameError({
+            enumName: self.spec.name,
+            name: name
+        }));
+    }
+    return bufrw.Int32BE.writeInto(value, buffer, offset);
+};
+
+EnumRW.prototype.readFrom = function readFrom(buffer, offset) {
+    var self = this;
+    var result;
+    result = bufrw.Int32BE.readFrom(buffer, offset);
+    // istanbul ignore if
+    if (result.err) {
+        return result;
+    }
+    offset = result.offset;
+    var value = result.value;
+    var name = self.spec.valuesToNames[value];
+    if (!name) {
+        return new ReadResult(errors.InvalidEnumerationValueError({
+            enumName: self.spec.name,
+            value: value
+        }));
+    }
+    return new ReadResult(null, offset, name);
+};
+
+module.exports.EnumSpec = EnumSpec;

--- a/errors.js
+++ b/errors.js
@@ -87,3 +87,25 @@ module.exports.FieldRequiredError = TypedError({
     structName: null,
     what: null
 });
+
+module.exports.InvalidEnumerationTypeError = TypedError({
+    type: 'thrift-invalid-enumeration-type',
+    message: 'name must be a string for enumeration {enumName}, got: {name} ({nameType})',
+    enumName: null,
+    name: null,
+    nameType: null
+});
+
+module.exports.InvalidEnumerationNameError = TypedError({
+    type: 'thrift-invalid-enumeration-name',
+    message: 'name must be a valid member of enumeration {enumName}, got: {name}',
+    enumName: null,
+    name: null
+});
+
+module.exports.InvalidEnumerationValueError = TypedError({
+    type: 'thrift-invalid-enumeration-value',
+    message: 'value must be a valid member of enumeration {enumName}, got: {value}',
+    enumName: null,
+    value: null
+});

--- a/errors.js
+++ b/errors.js
@@ -22,13 +22,14 @@
 
 var TypedError = require('error/typed');
 
-module.exports.ListTypeIdMismatch = TypedError({
-    type: 'thrift-list-typeid-mismatch',
-    message: 'encoded list typeid {encoded} doesn\'t match ' +
+module.exports.TypeIdMismatch = TypedError({
+    type: 'thrift-typeid-mismatch',
+    message: 'encoded {what} typeid {encoded} doesn\'t match ' +
         'expected type "{expected}" (id: {expectedId})',
     encoded: null,
     expected: null,
-    expectedId: null
+    expectedId: null,
+    what: null
 });
 
 module.exports.MapKeyTypeIdMismatch = TypedError({

--- a/errors.js
+++ b/errors.js
@@ -88,6 +88,12 @@ module.exports.FieldRequiredError = TypedError({
     what: null
 });
 
+module.exports.UnexpectedMapTypeAnnotation = TypedError({
+    type: 'thrift-unexpected-map-type-annotation',
+    message: 'unexpected map js.type annotation "{mapType}"',
+    mapType: null
+});
+
 module.exports.InvalidEnumerationTypeError = TypedError({
     type: 'thrift-invalid-enumeration-type',
     message: 'name must be a string for enumeration {enumName}, got: {name} ({nameType})',

--- a/exception.js
+++ b/exception.js
@@ -1,0 +1,75 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var assert = require('assert');
+var inherits = require('util').inherits;
+var TypedError = require('error/typed');
+var StructSpec = require('./struct').StructSpec;
+
+function ExceptionSpec() {
+    var self = this;
+    StructSpec.call(self);
+    self.type = null;
+    self.message = null;
+}
+
+inherits(ExceptionSpec, StructSpec);
+
+ExceptionSpec.prototype.compile = function compile(def) {
+    var self = this;
+    StructSpec.prototype.compile.call(self, def);
+    assert(def.annotations,
+        'annotations required for exception: ' + self.name);
+    assert(def.annotations.type,
+        'exceptions must have a type annotation: ' + self.name);
+    assert(typeof def.annotations.type === 'string',
+        'type annotation must be a string: ' + self.name);
+    assert(typeof def.annotations.message === 'string',
+        'message annotation must be a string: ' + self.name);
+    self.type = def.annotations.type;
+    self.message = def.annotations.message;
+};
+
+ExceptionSpec.prototype.createConstructor =
+function createConstructor(name, fieldNames) {
+    var self = this;
+    var declaration = {
+        type: self.type,
+        message: self.message
+    };
+    for (var index = 0; index < fieldNames.length; index++) {
+        var fieldName = fieldNames[index];
+        declaration[fieldName] = null;
+    }
+    return TypedError(declaration);
+};
+
+ExceptionSpec.prototype.create = function create() {
+    return {};
+};
+
+ExceptionSpec.prototype.finalize = function finalize(struct) {
+    var self = this;
+    return self.Constructor(struct);
+};
+
+module.exports.ExceptionSpec = ExceptionSpec;

--- a/i16.js
+++ b/i16.js
@@ -28,6 +28,7 @@ var I16RW = bufrw.Int16BE;
 function I16Spec() { }
 
 I16Spec.prototype.rw = I16RW;
+I16Spec.prototype.name = 'i16';
 I16Spec.prototype.typeid = TYPE.I16;
 
 module.exports.I16RW = I16RW;

--- a/i32.js
+++ b/i32.js
@@ -28,6 +28,7 @@ var I32RW = bufrw.Int32BE;
 function I32Spec() { }
 
 I32Spec.prototype.rw = I32RW;
+I32Spec.prototype.name = 'i32';
 I32Spec.prototype.typeid = TYPE.I32;
 
 module.exports.I32RW = I32RW;

--- a/i64.js
+++ b/i64.js
@@ -45,6 +45,7 @@ var I64RW = bufrw.AtomRW(8,
 function I64Spec() { }
 
 I64Spec.prototype.rw = I64RW;
+I64Spec.prototype.name = 'i64';
 I64Spec.prototype.typeid = TYPE.I64;
 
 module.exports.I64RW = I64RW;

--- a/index.js
+++ b/index.js
@@ -85,3 +85,5 @@ module.exports.StringSpec = require('./string').StringSpec;
 
 module.exports.VoidRW = require('./void').VoidRW;
 module.exports.VoidSpec = require('./void').VoidSpec;
+
+module.exports.Spec = require('./spec');

--- a/index.js
+++ b/index.js
@@ -75,6 +75,7 @@ module.exports.I64Spec = require('./i64').I64Spec;
 
 module.exports.ListRW = require('./list').ListRW;
 module.exports.ListSpec = require('./list').ListSpec;
+module.exports.SetSpec = require('./set').SetSpec;
 
 module.exports.SpecMapObjRW = require('./specmap-obj').SpecMapObjRW;
 module.exports.SpecMapEntriesRW = require('./specmap-entries').SpecMapEntriesRW;

--- a/list.js
+++ b/list.js
@@ -23,7 +23,6 @@
 
 var bufrw = require('bufrw');
 var TYPE = require('./TYPE');
-var typeNames = require('./names');
 var InvalidSizeError = require('./errors').InvalidSizeError;
 var ListTypeIdMismatch = require('./errors').ListTypeIdMismatch;
 
@@ -36,6 +35,9 @@ function ListSpec(valueType, annotations) {
     self.rw = new ListRW(valueType, self);
 }
 
+ListSpec.prototype.name = 'list';
+ListSpec.prototype.typeid = TYPE.LIST;
+
 ListSpec.prototype.create = function create() {
     return [];
 };
@@ -47,8 +49,6 @@ ListSpec.prototype.add = function add(list, value) {
 ListSpec.prototype.finalize = function finalize(list) {
     return list;
 };
-
-ListSpec.prototype.typeid = TYPE.LIST;
 
 function ListRW(valueType, spec) {
     var self = this;
@@ -114,8 +114,8 @@ ListRW.prototype.readFrom = function readFrom(buffer, offset) {
     if (valueTypeid !== valueType.typeid) {
         return new ReadResult(ListTypeIdMismatch({
             encoded: valueTypeid,
-            expected: typeNames[valueType.typeid],
-            expectedId: valueType.typeid
+            expectedId: valueType.typeid,
+            expected: valueType.name
         }));
     }
     if (size < 0) {

--- a/map.js
+++ b/map.js
@@ -20,30 +20,31 @@
 
 'use strict';
 
-require('./binary');
-require('./boolean');
-require('./byte');
-require('./double');
-require('./i16');
-require('./i32');
-require('./i64');
-require('./specmap-entries');
-require('./thrift-idl');
-require('./specmap-obj');
-require('./string');
-require('./tlist');
-require('./tmap');
-require('./tstruct');
-require('./void');
-require('./skip');
-require('./struct');
-require('./struct-skip');
-require('./exception');
-require('./service');
-require('./spec');
-require('./list');
-require('./set');
-require('./map');
-require('./const');
-require('./default');
-require('./enum');
+var TYPE = require('./TYPE');
+var SpecMapObjRW = require('./specmap-obj').SpecMapObjRW;
+var SpecMapEntriesRW = require('./specmap-entries').SpecMapEntriesRW;
+var UnexpectedMapTypeAnnotation = require('./errors').UnexpectedMapTypeAnnotation; // TODO
+
+var none = {};
+
+function MapSpec(keyType, valueType, annotations) {
+    var self = this;
+
+    annotations = annotations || none;
+    var type = annotations['js.type'] || 'object';
+
+    if (type === 'object') {
+        self.rw = new SpecMapObjRW(keyType, valueType);
+    } else if (type === 'entries') {
+        self.rw = new SpecMapEntriesRW(keyType, valueType);
+    } else {
+        throw UnexpectedMapTypeAnnotation({
+            mapType: type
+        });
+    }
+}
+
+MapSpec.prototype.name = 'map';
+MapSpec.prototype.typeid = TYPE.MAP;
+
+module.exports.MapSpec = MapSpec;

--- a/service.js
+++ b/service.js
@@ -41,7 +41,8 @@ FunctionSpec.prototype.compile = function process(def, spec) {
     self.args = new StructSpec({strict: self.strict});
     self.args = spec.compileStruct({
         id: {name: self.name + '_args', as: self.fullName + '_args'},
-        fields: def.fields
+        fields: def.fields,
+        isArgument: true
     });
 
     var resultFields = def.throws || [];
@@ -57,7 +58,8 @@ FunctionSpec.prototype.compile = function process(def, spec) {
 
     self.result = spec.compileStruct({
         id: {name: self.name + '_result', as: self.fullName + '_result'},
-        fields: resultFields
+        fields: resultFields,
+        isResult: true
     });
 };
 

--- a/set.js
+++ b/set.js
@@ -1,0 +1,91 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var util = require('util');
+var assert = require('assert');
+var ListSpec = require('./list').ListSpec;
+
+function SetSpec(valueType, annotations) {
+    // TODO consider annotations for {key: true} vs Set vs [] (default)
+    var self = this;
+    ListSpec.call(self, valueType, annotations);
+    self.mode = annotations && annotations['js.type'] || 'array';
+    assert(self.mode === 'array' || self.mode === 'object', 'js.type annotation must be either "array" or "object"');
+}
+
+util.inherits(SetSpec, ListSpec);
+
+SetSpec.prototype.name = 'set';
+
+SetSpec.prototype.create = function create() {
+    var self = this;
+    if (self.mode === 'array') {
+        return [];
+    } else { // if (self.mode === 'object') {
+        return {};
+    }
+};
+
+SetSpec.prototype.add = function add(set, value) {
+    var self = this;
+    if (self.mode === 'array') {
+        set.push(value);
+    } else { // if (self.mode === 'object') {
+        set[value] = true;
+    }
+};
+
+SetSpec.prototype.toArray = function toArray(set) {
+    var self = this;
+    var index;
+    var keys;
+    var values;
+    if (self.mode === 'array') {
+        assert(Array.isArray(set), 'set must be expressed as an array');
+        return set;
+    // else if (self.mode === 'object') {
+    } else if (self.valueType === 'string') {
+        keys = Object.keys(set);
+        values = [];
+        for (index = 0; index < keys.length; index++) {
+            // istanbul ignore else
+            if (set[keys[index]]) {
+                values.push(keys[index]);
+            }
+        }
+        return values;
+    } else { // numbers (coerce key to number)
+        keys = Object.keys(set);
+        values = [];
+        for (index = 0; index < keys.length; index++) {
+            // istanbul ignore else
+            if (set[keys[index]]) {
+                values.push(+keys[index]);
+            }
+        }
+        return values;
+    }
+};
+
+SetSpec.prototype.type = 'set';
+
+module.exports.SetSpec = SetSpec;

--- a/spec.js
+++ b/spec.js
@@ -27,7 +27,7 @@ var Result = require('bufrw/result');
 
 var ServiceSpec = require('./service').ServiceSpec;
 var StructSpec = require('./struct').StructSpec;
-// TODO var ExceptionSpec = require('./exception').ExceptionSpec;
+var ExceptionSpec = require('./exception').ExceptionSpec;
 // TODO var EnumSpec = require('./enum').EnumSpec;
 
 var VoidSpec = require('./void').VoidSpec;
@@ -109,7 +109,7 @@ Spec.prototype._definitionProcessors = {
     // sorted
     // TODO Const: 'compileConst',
     // TODO Enum: 'compileEnum',
-    // TODO Exception: 'compileException',
+    Exception: 'compileException',
     // TODO Senum: 'compileSenum',
     Service: 'compileService',
     Struct: 'compileStruct'
@@ -131,6 +131,16 @@ Spec.prototype.compileDefinitions = function compileDefinitions(defs) {
 Spec.prototype.compileStruct = function compileStruct(def) {
     var self = this;
     var spec = new StructSpec({strict: self.strict});
+    spec.compile(def, self);
+    self.claim(spec.fullName, def);
+    self.types[spec.fullName] = spec;
+    self[spec.fullName] = spec;
+    return spec;
+};
+
+Spec.prototype.compileException = function compileException(def) {
+    var self = this;
+    var spec = new ExceptionSpec({strict: self.strict});
     spec.compile(def, self);
     self.claim(spec.fullName, def);
     self.types[spec.fullName] = spec;

--- a/spec.js
+++ b/spec.js
@@ -40,7 +40,7 @@ var I32Spec = require('./i32').I32Spec;
 var I64Spec = require('./i64').I64Spec;
 var DoubleSpec = require('./double').DoubleSpec;
 var ListSpec = require('./list').ListSpec;
-// TODO var SetSpec = require('./set').SetSpec;
+var SetSpec = require('./set').SetSpec;
 // TODO var MapSpec = require('./map').MapSpec;
 
 function Spec(args) {
@@ -188,6 +188,8 @@ Spec.prototype.resolve = function resolve(def) {
         return self.types[def.name];
     } else if (def.type === 'List') {
         return new ListSpec(self.resolve(def.valueType), def.annotations);
+    } else if (def.type === 'Set') {
+        return new SetSpec(self.resolve(def.valueType), def.annotations);
     } else {
         err = new Error(util.format('Can\'t get reader/writer for definition with unknown type %s', def.type));
     }

--- a/spec.js
+++ b/spec.js
@@ -29,7 +29,7 @@ var Result = require('bufrw/result');
 var ServiceSpec = require('./service').ServiceSpec;
 var StructSpec = require('./struct').StructSpec;
 var ExceptionSpec = require('./exception').ExceptionSpec;
-// TODO var EnumSpec = require('./enum').EnumSpec;
+var EnumSpec = require('./enum').EnumSpec;
 
 var VoidSpec = require('./void').VoidSpec;
 var BooleanSpec = require('./boolean').BooleanSpec;
@@ -112,9 +112,8 @@ Spec.prototype.claim = function claim(name, def) {
 Spec.prototype._definitionProcessors = {
     // sorted
     Const: 'compileConst',
-    // TODO Enum: 'compileEnum',
+    Enum: 'compileEnum',
     Exception: 'compileException',
-    // TODO Senum: 'compileSenum',
     Service: 'compileService',
     Struct: 'compileStruct'
     // TODO Typedef: 'compileTypedef',
@@ -166,6 +165,14 @@ Spec.prototype.compileConst = function compileConst(def, spec) {
     var constSpec = new ConstSpec(def);
     self.claim(def.id.name, def.id);
     self.constSpecs[def.id.name] = constSpec;
+};
+
+Spec.prototype.compileEnum = function compileEnum(def) {
+    var self = this;
+    var spec = new EnumSpec();
+    spec.compile(def, self);
+    self.claim(spec.name, def.id);
+    self.types[spec.name] = spec;
 };
 
 Spec.prototype.link = function link() {

--- a/spec.js
+++ b/spec.js
@@ -42,7 +42,7 @@ var I64Spec = require('./i64').I64Spec;
 var DoubleSpec = require('./double').DoubleSpec;
 var ListSpec = require('./list').ListSpec;
 var SetSpec = require('./set').SetSpec;
-// TODO var MapSpec = require('./map').MapSpec;
+var MapSpec = require('./map').MapSpec;
 var ConstSpec = require('./const').ConstSpec;
 
 function Spec(options) {
@@ -216,6 +216,8 @@ Spec.prototype.resolve = function resolve(def) {
         return new ListSpec(self.resolve(def.valueType), def.annotations);
     } else if (def.type === 'Set') {
         return new SetSpec(self.resolve(def.valueType), def.annotations);
+    } else if (def.type === 'Map') {
+        return new MapSpec(self.resolve(def.keyType), self.resolve(def.valueType), def.annotations);
     } else {
         err = new Error(util.format('Can\'t get reader/writer for definition with unknown type %s', def.type));
     }

--- a/spec.js
+++ b/spec.js
@@ -152,7 +152,7 @@ Spec.prototype.compileException = function compileException(def) {
     return spec;
 };
 
-Spec.prototype.compileService = function compileService(def, spec) {
+Spec.prototype.compileService = function compileService(def) {
     var self = this;
     var service = new ServiceSpec({strict: self.strict});
     service.compile(def, self);

--- a/spec.js
+++ b/spec.js
@@ -229,7 +229,7 @@ Spec.prototype.resolve = function resolve(def) {
     } else if (def.type === 'Map') {
         return new MapSpec(self.resolve(def.keyType), self.resolve(def.valueType), def.annotations);
     } else {
-        err = new Error(util.format('Can\'t get reader/writer for definition with unknown type %s', def.type));
+        assert.fail(util.format('Can\'t get reader/writer for definition with unknown type %s', def.type));
     }
 };
 

--- a/string.js
+++ b/string.js
@@ -31,6 +31,7 @@ function StringSpec() {
 }
 
 StringSpec.prototype.rw = StringRW;
+StringSpec.prototype.name = 'string';
 StringSpec.prototype.typeid = TYPE.STRING;
 
 module.exports.StringRW = StringRW;

--- a/struct.js
+++ b/struct.js
@@ -74,6 +74,7 @@ function StructSpec(options) {
     self.rw = new StructRW(self);
 }
 
+StructSpec.prototype.name = 'struct';
 StructSpec.prototype.typeid = TYPE.STRUCT;
 
 StructSpec.prototype.compile = function compile(def) {

--- a/struct.js
+++ b/struct.js
@@ -57,6 +57,7 @@ function FieldSpec(def, struct) {
 FieldSpec.prototype.link = function link(spec) {
     var self = this;
     self.valueType = spec.resolve(self.valueDefinition);
+    assert(self.valueType, 'value type was defined, as returned by resolve');
 };
 
 FieldSpec.prototype.linkValue = function linkValue(spec) {
@@ -79,6 +80,7 @@ function StructSpec(options) {
     self.isArgument = null;
     self.Constructor = null;
     self.rw = new StructRW(self);
+    self.linked = false;
 }
 
 StructSpec.prototype.name = 'struct';
@@ -130,6 +132,12 @@ StructSpec.prototype.compile = function compile(def) {
 
 StructSpec.prototype.link = function link(spec) {
     var self = this;
+
+    if (self.linked) {
+        return self;
+    }
+    self.linked = true;
+
     var index;
 
     // Link default values first since they're used by the constructor
@@ -170,6 +178,8 @@ StructSpec.prototype.link = function link(spec) {
     for (index = 0; index < self.fields.length; index++) {
         self.fields[index].link(spec);
     }
+
+    return self;
 };
 
 // The following methods have alternate implementations for Exception and Union.

--- a/struct.js
+++ b/struct.js
@@ -84,6 +84,26 @@ function StructSpec(options) {
 StructSpec.prototype.name = 'struct';
 StructSpec.prototype.typeid = TYPE.STRUCT;
 
+StructSpec.prototype.toBuffer = function toBuffer(struct) {
+    var self = this;
+    return bufrw.toBuffer(self.rw, struct);
+};
+
+StructSpec.prototype.toBufferResult = function toBufferResult(struct) {
+    var self = this;
+    return bufrw.toBufferResult(self.rw, struct);
+};
+
+StructSpec.prototype.fromBuffer = function fromBuffer(buffer, offset) {
+    var self = this;
+    return bufrw.fromBuffer(self.rw, buffer, offset);
+};
+
+StructSpec.prototype.fromBufferResult = function fromBufferResult(buffer) {
+    var self = this;
+    return bufrw.fromBufferResult(self.rw, buffer);
+};
+
 StructSpec.prototype.compile = function compile(def) {
     var self = this;
     // Struct names must be valid JavaScript. If the Thrift name is not valid
@@ -137,6 +157,12 @@ StructSpec.prototype.link = function link(spec) {
 
     self.Constructor = self.createConstructor(self.name, self.fields);
     self.Constructor.rw = self.rw;
+
+    self.Constructor.fromBuffer = self.fromBuffer;
+    self.Constructor.fromBufferResult = self.fromBufferResult;
+
+    self.Constructor.toBuffer = self.toBuffer;
+    self.Constructor.toBufferResult = self.toBufferResult;
 
     // Link field types later since they may depend on the constructor existing
     // first.

--- a/struct.js
+++ b/struct.js
@@ -186,7 +186,7 @@ StructSpec.prototype.link = function link(spec) {
 
 StructSpec.prototype.createConstructor = function createConstructor(name, fields) {
     var source;
-    source = '(function $' + name + '(options) {\n';
+    source = '(function ' + name + '(options) {\n';
     for (var index = 0; index < fields.length; index++) {
         var field = fields[index];
         source += '    this.' + field.name + ' = null;\n';

--- a/test/const.js
+++ b/test/const.js
@@ -20,27 +20,20 @@
 
 'use strict';
 
-require('./binary');
-require('./boolean');
-require('./byte');
-require('./double');
-require('./i16');
-require('./i32');
-require('./i64');
-require('./specmap-entries');
-require('./thrift-idl');
-require('./specmap-obj');
-require('./string');
-require('./tlist');
-require('./tmap');
-require('./tstruct');
-require('./void');
-require('./skip');
-require('./struct');
-require('./struct-skip');
-require('./exception');
-require('./service');
-require('./spec');
-require('./list');
-require('./set');
-require('./const');
+var test = require('tape');
+
+var Spec = require('../spec');
+var fs = require('fs');
+var path = require('path');
+var source = fs.readFileSync(path.join(__dirname, 'const.thrift'), 'ascii');
+var spec;
+
+test('consts parse', function t(assert) {
+    spec = new Spec({source: source});
+    assert.equal(spec.consts.ten, 10, 'ten constant');
+    assert.equal(spec.consts.tenForward, 10, 'forward reference');
+    assert.deepEqual(spec.consts.edges, {0: 1, 1: 2}, 'map constant');
+    assert.deepEqual(spec.consts.names, ['a', 'ab', 'abc'], 'list constant');
+    assert.deepEqual(spec.consts.tens, [10, 10, 10], 'list of identifiers');
+    assert.end();
+});

--- a/test/const.thrift
+++ b/test/const.thrift
@@ -1,0 +1,8 @@
+const i32 tenForward = ten;
+const i32 ten = 10
+const map<i32, i32> edges = {
+    0: 1,
+    1: 2
+}
+const list<string> names = [ 'a', 'ab', 'abc' ]
+const list<i32> tens = [ ten, ten, ten ]

--- a/test/default.js
+++ b/test/default.js
@@ -25,11 +25,15 @@ var test = require('tape');
 var Spec = require('../spec');
 var fs = require('fs');
 var path = require('path');
-var source = fs.readFileSync(path.join(__dirname, 'service.thrift'), 'ascii');
-var spec = new Spec({source: source, strict: false});
+var source = fs.readFileSync(path.join(__dirname, 'default.thrift'), 'ascii');
+var spec;
 
-test('has args', function t(assert) {
-    assert.ok(spec.getType('Foo::foo_args'), 'has args');
-    assert.ok(spec.Foo.foo.args, 'has args exposed on service object');
+test('default values on structs work', function t(assert) {
+    spec = new Spec({source: source});
+    var health = new spec.Health({name: 'grand'});
+    assert.equals(health.ok, true, 'default truth value passes through');
+    assert.equals(health.notOk, false, 'default false value passes through');
+    assert.equals(health.message, 'OK', 'default string passes through');
+    assert.equals(health.name, 'grand', 'option overrides default');
     assert.end();
 });

--- a/test/default.thrift
+++ b/test/default.thrift
@@ -1,0 +1,6 @@
+struct Health {
+    1: bool ok = true
+    2: bool notOk = false
+    3: string message = 'OK'
+    4: string name = 'alright'
+}

--- a/test/enum-collision.thrift
+++ b/test/enum-collision.thrift
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Contains some contributions under the Thrift Software License.
+ * Please see doc/old-thrift-license.txt in the Thrift distribution for
+ * details.
+ */
+
+enum MyEnum4 {
+    A
+    A
+}
+
+struct MyStruct {
+  1: MyEnum enum = MyEnum.A
+}

--- a/test/enum-overflow.thrift
+++ b/test/enum-overflow.thrift
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Contains some contributions under the Thrift Software License.
+ * Please see doc/old-thrift-license.txt in the Thrift distribution for
+ * details.
+ */
+
+enum MyEnum4 {
+  ME4_A = 0x7ffffffd
+  ME4_B
+  ME4_C
+  // attempting to define another enum value here fails
+  // with an overflow error, as we overflow values that can be
+  // represented with an i32.
+  ME4_D
+}
+
+struct MyStruct {
+  1: MyEnum4 enum
+}

--- a/test/enum.js
+++ b/test/enum.js
@@ -1,0 +1,142 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+/* global Buffer */
+/* eslint camelcase:[0] */
+/* eslint no-new:[0] */
+'use strict';
+
+var tape = require('tape');
+var fs = require('fs');
+var path = require('path');
+var Spec = require('../').Spec;
+var spec;
+var MyStruct;
+
+tape('parse enum.thrift', function t(assert) {
+    var source = fs.readFileSync(path.join(__dirname, 'enum.thrift'), 'ascii');
+    spec = new Spec({source: source});
+    MyStruct = spec.getType('MyStruct');
+    assert.end();
+});
+
+tape('round trip an enum', function t(assert) {
+    var inStruct = {me2_2: 'ME2_2', me3_n2: 'ME3_N2', me3_d1: 'ME3_D1'};
+    var buffer = MyStruct.toBuffer(inStruct);
+    var outStruct = MyStruct.fromBuffer(buffer);
+    assert.deepEquals(outStruct, inStruct);
+    assert.end();
+});
+
+tape('first enum is 0 by default', function t(assert) {
+    var inStruct = {me2_2: null, me3_n2: null, me3_d1: 'ME3_0'};
+    var buffer = MyStruct.toBuffer(inStruct);
+    var expected = new Buffer([
+        0x08, 0x00, // struct
+        0x03, // field number 3
+        0x00, 0x00, 0x00, 0x00, // value 0
+        0x00
+    ]);
+    assert.deepEqual(buffer, expected);
+    assert.end();
+});
+
+tape('count resumes from previous enum', function t(assert) {
+    var inStruct = {me2_2: null, me3_n2: null, me3_d1: 'ME3_N1'};
+    var buffer = MyStruct.toBuffer(inStruct);
+    var expected = new Buffer([
+        0x08,                   // typeid:1 -- 8, struct
+        0x00, 0x03,             // field:2  -- 3
+        0xff, 0xff, 0xff, 0xff, // value~4  -- -1
+        0x00                    // typeid:1 -- 0, stop
+    ]);
+    assert.deepEqual(buffer, expected);
+    assert.end();
+});
+
+tape('duplicate name permitted', function t(assert) {
+    var inStruct = {me2_2: null, me3_n2: null, me3_d1: 'ME3_D0'};
+    var buffer = MyStruct.toBuffer(inStruct);
+    var expected = new Buffer([
+        0x08,                   // typeid:1 -- 0, struct
+        0x00, 0x03,             // field~2  -- 3
+        0x00, 0x00, 0x00, 0x00, // value~4  -- 0
+        0x00                    // typeid:1 -- 0, stop
+    ]);
+    assert.deepEqual(buffer, expected);
+    assert.end();
+});
+
+tape('duplicate name returns in normal form', function t(assert) {
+    var inStruct = {me2_2: null, me3_n2: null, me3_d1: 'ME3_D0'};
+    var buffer = MyStruct.toBuffer(inStruct);
+    var outStruct = MyStruct.fromBuffer(buffer);
+    assert.deepEqual(outStruct, {
+        me2_2: 'ME2_2',
+        me3_n2: 'ME3_N2',
+        me3_d1: 'ME3_D0'
+    });
+    assert.end();
+});
+
+tape('throws on name collision', function t(assert) {
+    assert.throws(function throws() {
+        var source = fs.readFileSync(path.join(__dirname, 'enum-collision.thrift'), 'ascii');
+        new Spec({source: source});
+    }, /duplicate name in enum MyEnum4 at 24:6/);
+    assert.end();
+});
+
+tape('throws on overflow', function t(assert) {
+    assert.throws(function throws() {
+        var source = fs.readFileSync(path.join(__dirname, 'enum-overflow.thrift'), 'ascii');
+        new Spec({source: source});
+    }, /overflow in value in enum MyEnum4 at 24:6/);
+    assert.end();
+});
+
+tape('can\'t encode non-name', function t(assert) {
+    var inStruct = {me3_d1: -1};
+    assert.throws(function throws() {
+        MyStruct.toBuffer(inStruct);
+    }, /name must be a string for enumeration MyEnum3, got: -1 \(number\)/);
+    assert.end();
+});
+
+tape('can\'t encode unknown name', function t(assert) {
+    var inStruct = {me3_d1: 'BOGUS'};
+    assert.throws(function throws() {
+        MyStruct.toBuffer(inStruct);
+    }, /name must be a valid member of enumeration MyEnum3, got: BOGUS/);
+    assert.end();
+});
+
+tape('can\'t decode unknown number', function t(assert) {
+    var buffer = new Buffer([
+        0x08,                   // typeid:1  -- 8, struct
+        0x00, 0x03,             // fieldid:2 -- 3
+        0x00, 0x00, 0x00, 0x0b, // value:4   -- 11
+        0x00                    // typeid:1  -- 0, stop
+    ]);
+    assert.throws(function throws() {
+        MyStruct.fromBuffer(buffer);
+    }, /value must be a valid member of enumeration MyEnum3, got: 11/);
+    assert.end();
+});

--- a/test/enum.thrift
+++ b/test/enum.thrift
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Contains some contributions under the Thrift Software License.
+ * Please see doc/old-thrift-license.txt in the Thrift distribution for
+ * details.
+ */
+
+enum MyEnum1 {
+  ME1_0 = 0,
+  ME1_1 = 1,
+  ME1_2,
+  ME1_3,
+  ME1_5 = 5,
+  ME1_6,
+}
+
+enum MyEnum2 {
+  ME2_0,
+  ME2_1,
+  ME2_2,
+}
+
+enum MyEnum2_again {
+  // enum value identifiers may appear again in another enum type
+  ME0_1,
+  ME1_1,
+  ME2_1,
+  ME3_1,
+}
+
+enum MyEnum3 {
+  ME3_0,
+  ME3_1,
+  ME3_N2 = -2,
+  ME3_N1,
+  ME3_D0,
+  ME3_D1,
+  ME3_9 = 9,
+  ME3_10,
+}
+
+enum MyEnum4 {
+  ME4_A = 0x7ffffffd
+  ME4_B
+  ME4_C
+  // attempting to define another enum value here fails
+  // with an overflow error, as we overflow values that can be
+  // represented with an i32.
+}
+
+struct MyStruct {
+  1: MyEnum2 me2_2 = MyEnum2.ME2_2
+  2: MyEnum3 me3_n2 = MyEnum3.ME3_N2
+  3: MyEnum3 me3_d1 = MyEnum3.ME3_D1
+}

--- a/test/exception.js
+++ b/test/exception.js
@@ -24,25 +24,14 @@ var test = require('tape');
 var testRW = require('bufrw/test_rw');
 var fs = require('fs');
 var path = require('path');
-var idl = require('../thrift-idl');
-var ExceptionSpec = require('../exception').ExceptionSpec;
-var StringSpec = require('../string').StringSpec;
+var Spec = require('../spec');
 
 var source = fs.readFileSync(path.join(__dirname, 'exception.thrift'), 'ascii');
-var ast = idl.parse(source);
+var spec = new Spec({source: source});
 
-var mockSpec = {
-    resolve: function resolve() {
-        return new StringSpec();
-    }
-};
-var bogusErrorSpec = new ExceptionSpec();
-bogusErrorSpec.compile(ast.definitions[0]);
-bogusErrorSpec.link(mockSpec);
+test('Exception RW', testRW.cases(spec.BogusNameError.rw, [
 
-test('Exception RW', testRW.cases(bogusErrorSpec.rw, [
-
-    [bogusErrorSpec.Constructor({bogusName: 'Voldemort'}), [
+    [spec.BogusNameError({bogusName: 'Voldemort'}), [
         0x0b, // typeid:1 = 11, STRING
         0x00, 0x01, // id:2 = 1, bogusName
         0x00, 0x00, 0x00, 0x09, // str_len:4 = 9

--- a/test/exception.thrift
+++ b/test/exception.thrift
@@ -1,0 +1,6 @@
+exception BogusNameError {
+    1: required string bogusName
+} (
+    type = 'bogus-name-error'
+    message = 'Bogus name: {bogusName}'
+)

--- a/test/index.js
+++ b/test/index.js
@@ -42,3 +42,4 @@ require('./exception');
 require('./service');
 require('./spec');
 require('./list');
+require('./set');

--- a/test/index.js
+++ b/test/index.js
@@ -44,3 +44,4 @@ require('./spec');
 require('./list');
 require('./set');
 require('./const');
+require('./default');

--- a/test/index.js
+++ b/test/index.js
@@ -45,3 +45,4 @@ require('./list');
 require('./set');
 require('./const');
 require('./default');
+require('./enum');

--- a/test/index.js
+++ b/test/index.js
@@ -38,6 +38,7 @@ require('./void');
 require('./skip');
 require('./struct');
 require('./struct-skip');
+require('./recursion');
 require('./exception');
 require('./service');
 require('./spec');

--- a/test/list.js
+++ b/test/list.js
@@ -52,8 +52,8 @@ test('ListSpec.rw: list of bytes', testRW.cases(byteList.rw, [
                 0x00, 0x00, 0x00, 0x00 // length:4 -- 0
             ],
             error: {
-                type: 'thrift-list-typeid-mismatch',
-                name: 'ThriftListTypeidMismatchError',
+                type: 'thrift-typeid-mismatch',
+                name: 'ThriftTypeidMismatchError',
                 message: 'encoded list typeid 43 doesn\'t match expected ' +
                          'type "byte" (id: 3)'
             }

--- a/test/list.js
+++ b/test/list.js
@@ -55,7 +55,7 @@ test('ListSpec.rw: list of bytes', testRW.cases(byteList.rw, [
                 type: 'thrift-list-typeid-mismatch',
                 name: 'ThriftListTypeidMismatchError',
                 message: 'encoded list typeid 43 doesn\'t match expected ' +
-                         'type "BYTE" (id: 3)'
+                         'type "byte" (id: 3)'
             }
         }
     },

--- a/test/map.js
+++ b/test/map.js
@@ -1,0 +1,179 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
+var path = require('path');
+var fs = require('fs');
+var MapSpec = require('../map').MapSpec;
+var Spec = require('../spec');
+var spec;
+
+var StringSpec = require('../string').StringSpec;
+var I16Spec = require('../i16').I16Spec;
+
+test('spec parses', function t(assert) {
+    var filename = path.join(__dirname, 'map.thrift');
+    var source = fs.readFileSync(filename, 'ascii');
+    spec = new Spec({source: source});
+    spec.getType('Graph');
+    assert.pass('spec parses');
+    assert.end();
+});
+
+var strI16Map = new MapSpec(new StringSpec(), new I16Spec(), {});
+test('MapSpec: strI16MapRW', testRW.cases(strI16Map.rw, [
+    [{}, [
+        0x0b,                  // key_type:1 -- 11, string
+        0x06,                  // val_type:1 -- 6, i16
+        0x00, 0x00, 0x00, 0x00 // length:4   -- 0
+    ]],
+
+    [{
+        'abc': 1,
+        'def': 2,
+        'ghi': 3
+    }, [
+        0x0b,                   // key_type:1 -- 11, string
+        0x06,                   // val_type:1 -- 6, i16
+        0x00, 0x00, 0x00, 0x03, // length:4   -- 3
+                                //            --
+        0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
+        0x61, 0x62, 0x63,       // chars      -- "abc"
+        0x00, 0x01,             // Int16BE    -- 1
+                                //            --
+        0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
+        0x64, 0x65, 0x66,       // chars      -- "def"
+        0x00, 0x02,             // Int16BE    -- 2
+                                //            --
+        0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
+        0x67, 0x68, 0x69,       // chars      -- "ghi"
+        0x00, 0x03              // Int16BE    -- 3
+    ]],
+
+    {
+        readTest: {
+            bytes: [
+                0x09,                  // key_type:1 -- 9
+                0x02,                  // val_type:1 -- 2
+                0x00, 0x00, 0x00, 0x00 // length:4   -- 0
+            ],
+            error: {
+                type: 'thrift-map-key-typeid-mismatch',
+                name: 'ThriftMapKeyTypeidMismatchError',
+                message: 'encoded map key typeid 9 doesn\'t match expected ' +
+                         'type "string" (id: 11)'
+            }
+        }
+    },
+
+    {
+        readTest: {
+            bytes: [
+                0x0b,                  // key_type:1 -- 11
+                0x09,                  // val_type:1 -- 9
+                0x00, 0x00, 0x00, 0x00 // length:4   -- 0
+            ],
+            error: {
+                type: 'thrift-map-val-typeid-mismatch',
+                name: 'ThriftMapValTypeidMismatchError',
+                message: 'encoded map value typeid 9 doesn\'t match expected ' +
+                         'type "i16" (id: 6)'
+            }
+        }
+    }
+
+]));
+
+var strI16MapEntries = new MapSpec(new StringSpec(), new I16Spec(), {'js.type': 'entries'});
+test('MapSpec: strI16MapRW', testRW.cases(strI16MapEntries.rw, [
+    [[], [
+        0x0b,                  // key_type:1 -- 11, string
+        0x06,                  // val_type:1 -- 6, i16
+        0x00, 0x00, 0x00, 0x00 // length:4   -- 0
+    ]],
+
+    [[
+        ['abc', 1],
+        ['def', 2],
+        ['ghi', 3]
+    ], [
+        0x0b,                   // key_type:1 -- 11, string
+        0x06,                   // val_type:1 -- 6, i16
+        0x00, 0x00, 0x00, 0x03, // length:4   -- 3
+                                //            --
+        0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
+        0x61, 0x62, 0x63,       // chars      -- "abc"
+        0x00, 0x01,             // Int16BE    -- 1
+                                //            --
+        0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
+        0x64, 0x65, 0x66,       // chars      -- "def"
+        0x00, 0x02,             // Int16BE    -- 2
+                                //            --
+        0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
+        0x67, 0x68, 0x69,       // chars      -- "ghi"
+        0x00, 0x03              // Int16BE    -- 3
+    ]],
+
+    {
+        readTest: {
+            bytes: [
+                0x09,                  // key_type:1 -- 9
+                0x02,                  // val_type:1 -- 2
+                0x00, 0x00, 0x00, 0x00 // length:4   -- 0
+            ],
+            error: {
+                type: 'thrift-map-key-typeid-mismatch',
+                name: 'ThriftMapKeyTypeidMismatchError',
+                message: 'encoded map key typeid 9 doesn\'t match expected ' +
+                         'type "string" (id: 11)'
+            }
+        }
+    },
+
+    {
+        readTest: {
+            bytes: [
+                0x0b,                  // key_type:1 -- 11
+                0x09,                  // val_type:1 -- 9
+                0x00, 0x00, 0x00, 0x00 // length:4   -- 0
+            ],
+            error: {
+                type: 'thrift-map-val-typeid-mismatch',
+                name: 'ThriftMapValTypeidMismatchError',
+                message: 'encoded map value typeid 9 doesn\'t match expected ' +
+                         'type "i16" (id: 6)'
+            }
+        }
+    }
+
+]));
+
+test('invalid map type annotation', function t(assert) {
+    try {
+        var graphSpec = new Spec({source: 'struct Graph { 1: required map<byte, byte> (js.type = "bogus") edges }'});
+        assert.ok(!graphSpec, 'should not parse');
+    } catch (err) {
+        assert.equals(err.message, 'unexpected map js.type annotation "bogus"', 'error message');
+    }
+    assert.end();
+});

--- a/test/map.thrift
+++ b/test/map.thrift
@@ -1,0 +1,3 @@
+struct Graph {
+    1: required map<string, i16> edges
+}

--- a/test/recursion.js
+++ b/test/recursion.js
@@ -1,0 +1,96 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
+
+var Spec = require('../spec');
+var fs = require('fs');
+var path = require('path');
+var source = fs.readFileSync(path.join(__dirname, 'recursion.thrift'), 'ascii');
+var spec = new Spec({source: source});
+var Shark = spec.Shark;
+
+test('recursive rw', testRW.cases(Shark.rw, [
+
+    [new Shark(), [
+        0x00 // type:1 -- 0 -- stop
+    ]],
+
+    [new Shark({left: new Shark(), right: new Shark()}), [
+        0x0c,       // type:1 -- 12 -- STRUCT
+        0x00, 0x02, // id:2   -- 2  -- left
+        0x00,       // typeid -- 0  -- STOP
+        0x0c,       // type:1 -- 12 -- STRUCT
+        0x00, 0x03, // id:2   -- 3  -- right
+        0x00,       // typeid -- 0  -- STOP
+        0x00        // type:1 -- 0  -- STOP
+    ]],
+
+    [new Shark({name: 'Katie'}), [
+        0x0b,                         // type:1  -- 11 -- STRING
+        0x00, 0x01,                   // id:2    -- 1  -- name
+        0x00, 0x00, 0x00, 0x05,       // name~4  -- 5
+        0x4b, 0x61, 0x74, 0x69, 0x65, // 'Katie'
+        0x00                          // type:1  -- 0  -- STOP
+    ]],
+
+    [new Shark({name: 'Katie', left: new Shark()}), [
+        0x0b,                         // type:1  -- 11 -- STRING
+        0x00, 0x01,                   // id:2    -- 1  -- name
+        0x00, 0x00, 0x00, 0x05,       // name~4  -- 5
+        0x4b, 0x61, 0x74, 0x69, 0x65, // 'Katie'
+        0x0c,                         // type:1  -- 12 -- STRUCT
+        0x00, 0x02,                   // id:2    -- 2  -- left
+        0x00,                         // typeid  -- 0  -- STOP
+        0x00                          // type:1  -- 0  -- STOP
+    ]],
+
+    [new Shark({name: 'Katie', right: new Shark({right: new Shark()})}), [
+        0x0b,                         // type:1  -- 11 -- STRING
+        0x00, 0x01,                   // id:2    -- 1  -- name
+        0x00, 0x00, 0x00, 0x05,       // name~4  -- 5
+        0x4b, 0x61, 0x74, 0x69, 0x65, // 'Katie'
+        0x0c,                         // type:1  -- 12 -- STRUCT
+        0x00, 0x03,                   // id:2    -- 3  -- right
+        0x0c,                         // type:1  -- 12 -- STRUCT
+        0x00, 0x03,                   // id:2    -- 3  -- right
+        0x00,                         // typeid  -- 0  -- STOP
+        0x00,                         // typeid  -- 0  -- STOP
+        0x00                          // type:1  -- 0  -- STOP
+    ]],
+
+    {
+        readTest: {
+            bytes: [
+                0x0b,      // type:1 -- 11 -- STRING
+                0x00, 0x02 // id:2   -- 2  -- left
+            ],
+            error: {
+                type: 'thrift-unexpected-field-value-typeid',
+                name: 'ThriftUnexpectedFieldValueTypeidError',
+                message: 'unexpected typeid 11 (STRING) for field "left" with id 2 on Shark; expected 12 (STRUCT)'
+            }
+        }
+    }
+
+]));

--- a/test/recursion.thrift
+++ b/test/recursion.thrift
@@ -1,0 +1,5 @@
+struct Shark {
+  1: optional string name;
+  2: optional Shark left;
+  3: optional Shark right;
+}

--- a/test/set.js
+++ b/test/set.js
@@ -1,0 +1,164 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
+var fs = require('fs');
+var path = require('path');
+
+var Spec = require('../spec');
+var SetSpec = require('../set').SetSpec;
+var StringSpec = require('../string').StringSpec;
+var ByteSpec = require('../byte').ByteSpec;
+
+var byteSet = new SetSpec(new ByteSpec());
+var stringSet = new SetSpec(new StringSpec());
+var stringObjectSet = new SetSpec(new StringSpec(), {'js.type': 'object'});
+
+test('SetSpec.rw: set of bytes', testRW.cases(byteSet.rw, [
+
+    [[], [
+        0x03,                  // type:1   -- 3, BYTE
+        0x00, 0x00, 0x00, 0x00 // length:4 -- 0
+    ]],
+
+    [[1, 2, 3], [
+        0x03,                   // type:1   -- 3, BYTE
+        0x00, 0x00, 0x00, 0x03, // length:4 -- 3
+        0x01,                   // byte:1 -- 1
+        0x02,                   // byte:1 -- 2
+        0x03                    // byte:1 -- 3
+    ]],
+
+    {
+        readTest: {
+            bytes: [
+                0x2b,                  // type:1
+                0x00, 0x00, 0x00, 0x00 // length:4 -- 0
+            ],
+            error: {
+                type: 'thrift-typeid-mismatch',
+                name: 'ThriftTypeidMismatchError',
+                message: 'encoded set typeid 43 doesn\'t match expected ' +
+                         'type "byte" (id: 3)'
+            }
+        }
+    },
+
+    {
+        readTest: {
+            bytes: [
+                0x03,                  // type:1 -- 3, BYTE
+                0xff, 0xff, 0xff, 0xff // length:4 -- -1
+            ],
+            error: {
+                type: 'thrift-invalid-size',
+                name: 'ThriftInvalidSizeError',
+                message: 'invalid size -1 of set; expects non-negative number'
+            }
+        }
+    }
+
+]));
+
+test('SetSpec.rw: set of strings', testRW.cases(stringSet.rw, [
+
+    [[], [
+        0x0b,                  // type:1   -- 11, STRING
+        0x00, 0x00, 0x00, 0x00 // length:4 -- 0
+    ]],
+
+    [['a', 'ab', 'abc'], [
+        0x0b,                    // type:1    -- 11, STRING
+        0x00, 0x00, 0x00, 0x03,  // length:4  -- 3
+        0x00, 0x00, 0x00, 0x01,  // str_len:4 -- 1
+        0x61,                    // chars     -- "a"
+        0x000, 0x00, 0x00, 0x02, // str_len:4 -- 1
+        0x61, 0x62,              // chars     -- "ab"
+        0x00, 0x00, 0x00, 0x03,  // str_len:4 -- 1
+        0x61, 0x62, 0x63         // chars     -- "abc"
+    ]]
+
+]));
+
+test('SetSpec.rw: set of strings as object', testRW.cases(stringObjectSet.rw, [
+
+    [{}, [
+        0x0b,                  // type:1   -- 11, STRING
+        0x00, 0x00, 0x00, 0x00 // length:4 -- 0
+    ]],
+
+    [{a: true, ab: true, abc: true}, [
+        0x0b,                    // type:1    -- 11, STRING
+        0x00, 0x00, 0x00, 0x03,  // length:4  -- 3
+        0x00, 0x00, 0x00, 0x01,  // str_len:4 -- 1
+        0x61,                    // chars     -- "a"
+        0x000, 0x00, 0x00, 0x02, // str_len:4 -- 1
+        0x61, 0x62,              // chars     -- "ab"
+        0x00, 0x00, 0x00, 0x03,  // str_len:4 -- 1
+        0x61, 0x62, 0x63         // chars     -- "abc"
+    ]]
+
+]));
+
+var source = fs.readFileSync(path.join(__dirname, 'set.thrift'), 'ascii');
+var spec = new Spec({source: source});
+
+test('Struct with set rw', testRW.cases(spec.Bucket.rw, [
+
+    [new spec.Bucket({asArray: [1, 2, 3]}), [
+        0x0f,                   // type:1  -- 15, struct
+        0x00, 0x01,             // field:2 -- 1, asArray
+        0x08,                   // type:1  -- 8, i32
+        0x00, 0x00, 0x00, 0x03, // len:4   -- 3
+        0x00, 0x00, 0x00, 0x01, // value:4 -- 1
+        0x00, 0x00, 0x00, 0x02, // value:4 -- 2
+        0x00, 0x00, 0x00, 0x03, // value:4 -- 3
+        0x00                    // type:1  -- 0, stop
+    ]],
+
+    [new spec.Bucket({numbersAsObject: {1: true, 2: true, 3: true}}), [
+        0x0f,                   // type:1  -- 15, struct
+        0x00, 0x02,             // field:2 -- 1, numbersAsObject
+        0x08,                   // type:1  -- 8, i32
+        0x00, 0x00, 0x00, 0x03, // len:4   -- 3
+        0x00, 0x00, 0x00, 0x01, // value:4 -- 1
+        0x00, 0x00, 0x00, 0x02, // value:4 -- 2
+        0x00, 0x00, 0x00, 0x03, // value:4 -- 3
+        0x00                    // type:1  -- 0, stop
+    ]],
+
+    [new spec.Bucket({stringsAsObject: {1: true, 2: true, 3: true}}), [
+        0x0f,                   // type:1       -- 15, struct
+        0x00, 0x03,             // field:2      -- 1, numbersAsObject
+        0x0b,                   // type:1       -- 11, string
+        0x00, 0x00, 0x00, 0x03, // length:4     -- 3
+        0x00, 0x00, 0x00, 0x01, // [0] length:4 -- 1
+        0x31,                   // '1'
+        0x00, 0x00, 0x00, 0x01, // [1] length:4 -- 1
+        0x32,                   // '2'
+        0x00, 0x00, 0x00, 0x01, // [2] length:4 -- 1
+        0x33,                   // '3'
+        0x00                    // type:1       -- 0, stop
+    ]]
+
+]));

--- a/test/set.thrift
+++ b/test/set.thrift
@@ -1,0 +1,5 @@
+struct Bucket {
+    1: optional set<i32> asArray
+    2: optional set<i32> (js.type = 'object') numbersAsObject
+    3: optional set<string> (js.type = 'object') stringsAsObject
+}

--- a/test/spec.js
+++ b/test/spec.js
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+/* global Buffer */
 'use strict';
 
 var fs = require('fs');
@@ -43,8 +44,54 @@ test('can get type result from spec', function t(assert) {
 });
 
 test('can get type from spec', function t(assert) {
-    var Struct = spec.getTypeResult('Struct');
+    var Struct = spec.getType('Struct');
     assert.ok(Struct, 'got struct');
+    assert.end();
+});
+
+test('can read struct from buffer', function t(assert) {
+    var struct = spec.Struct.fromBuffer(new Buffer([
+        0x08, // typeid:1 -- 8, i32
+        0x00, 0x01, // id:2 -- 1, "number"
+        0x00, 0x00, 0x00, 0x0a, // number:4 -- 10
+        0x00 // typeid:1 -- 0, stop
+    ]));
+    assert.ok(struct instanceof spec.Struct, 'struct instanceof Strict');
+    assert.deepEqual(struct, new spec.Struct({number: 10}), 'struct properties read properly');
+    assert.end();
+});
+
+test('can read struct result from buffer', function t(assert) {
+    var result = spec.Struct.fromBufferResult(new Buffer([
+        0x08, // typeid:1 -- 8, i32
+        0x00, 0x01, // id:2 -- 1, "number"
+        0x00, 0x00, 0x00, 0x0a, // number:4 -- 10
+        0x00 // typeid:1 -- 0, stop
+    ]));
+    assert.ok(result.value instanceof spec.Struct, 'struct instanceof Strict');
+    assert.deepEqual(result.value, new spec.Struct({number: 10}), 'struct properties read properly');
+    assert.end();
+});
+
+test('can write struct to buffer', function t(assert) {
+    var buffer = spec.Struct.toBuffer(new spec.Struct({number: 10}));
+    assert.deepEqual(buffer, new Buffer([
+        0x08, // typeid:1 -- 8, i32
+        0x00, 0x01, // id:2 -- 1, "number"
+        0x00, 0x00, 0x00, 0x0a, // number:4 -- 10
+        0x00 // typeid:1 -- 0, stop
+    ]));
+    assert.end();
+});
+
+test('can write struct to buffer', function t(assert) {
+    var result = spec.Struct.toBufferResult(new spec.Struct({number: 10}));
+    assert.deepEqual(result.value, new Buffer([
+        0x08, // typeid:1 -- 8, i32
+        0x00, 0x01, // id:2 -- 1, "number"
+        0x00, 0x00, 0x00, 0x0a, // number:4 -- 10
+        0x00 // typeid:1 -- 0, stop
+    ]));
     assert.end();
 });
 

--- a/test/spec.thrift
+++ b/test/spec.thrift
@@ -1,5 +1,6 @@
 
 struct Struct {
+    1: required i32 number
 }
 
 service Service {

--- a/test/struct.js
+++ b/test/struct.js
@@ -35,6 +35,8 @@ var mockSpec = {
     resolve: function resolve() {
         // pretend all fields are boolean
         return new BooleanSpec();
+    },
+    resolveValue: function resolveValue() {
     }
 };
 
@@ -250,37 +252,11 @@ test('every field must be marked in strict mode', function t(assert) {
                 }
             ]
         });
+        spec.link(mockSpec);
         assert.fail('should throw');
     } catch (err) {
-        assert.equal(err.message, 'every field must be marked optional or ' +
-            'required on Health including "ok" in strict mode');
-    }
-    assert.end();
-});
-
-test('every argument must be marked required in strict mode', function t(assert) {
-    var spec = new StructSpec();
-    try {
-        spec.compile({
-            id: {name: 'function_args'},
-            isArgument: true,
-            fields: [
-                {
-                    id: {value: 1},
-                    name: 'namedParam',
-                    valueType: {
-                        type: 'BaseType',
-                        baseType: 'boolean'
-                    },
-                    optional: true,
-                    required: false
-                }
-            ]
-        });
-        assert.fail('should throw');
-    } catch (err) {
-        assert.equal(err.message, 'every field must be marked ' +
-            'required on function_args including "namedParam" in strict mode');
+        assert.equal(err.message, 'every field must be marked optional, ' +
+            'required, or have a default value on Health including "ok" in strict mode');
     }
     assert.end();
 });
@@ -350,6 +326,7 @@ test('arguments must not be marked optional', function t(assert) {
                 }
             ]
         });
+        argStruct.link(mockSpec);
         assert.fail('should fail to write');
     } catch (err) {
         assert.equal(err.message, 'no field of an argument struct may be ' +

--- a/test/typedef.js
+++ b/test/typedef.js
@@ -20,31 +20,31 @@
 
 'use strict';
 
-require('./binary');
-require('./boolean');
-require('./byte');
-require('./double');
-require('./i16');
-require('./i32');
-require('./i64');
-require('./specmap-entries');
-require('./thrift-idl');
-require('./specmap-obj');
-require('./string');
-require('./tlist');
-require('./tmap');
-require('./tstruct');
-require('./void');
-require('./skip');
-require('./struct');
-require('./struct-skip');
-require('./exception');
-require('./service');
-require('./spec');
-require('./list');
-require('./set');
-require('./map');
-require('./typedef');
-require('./const');
-require('./default');
-require('./enum');
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
+var fs = require('fs');
+var path = require('path');
+var Spec = require('../spec');
+
+var source = fs.readFileSync(path.join(__dirname, 'typedef.thrift'), 'ascii');
+var spec = new Spec({source: source});
+
+test('follows references through typedefs', function t(assert) {
+    assert.strictEqual(spec.getType('Structure'), spec.getType('Tree'));
+    assert.end();
+});
+
+test('Typedef rw', testRW.cases(spec.Tree.rw, [
+
+    [new spec.Tree({value: 0, children: []}), [
+        0x08,                   // typeid:1  -- 8, i32
+        0x00, 0x01,             // id:2      -- 1, "value"
+        0x00, 0x00, 0x00, 0x00, // value:4   -- 0
+        0x0f,                   // typeid:1  -- 15, list
+        0x00, 0x02,             // id:2      -- 2, "children"
+        0x0c,                   // el_type:1 -- struct
+        0x00, 0x00, 0x00, 0x00, // length:4  -- 0
+        0x00                    // typeid:1  -- 0, stop
+    ]]
+
+]));

--- a/test/typedef.thrift
+++ b/test/typedef.thrift
@@ -1,0 +1,8 @@
+typedef Tree Structure
+typedef i32 int
+typedef list<Tree> Branches
+
+struct Tree {
+    1: required int value
+    2: required Branches children
+}

--- a/thrift-idl.pegjs
+++ b/thrift-idl.pegjs
@@ -60,6 +60,22 @@
     }
     Const.prototype.type = 'Const';
 
+    function ConstList(values) {
+        this.values = values;
+    }
+    ConstList.prototype.type = 'ConstList';
+
+    function ConstMap(entries) {
+        this.entries = entries;
+    }
+    ConstMap.prototype.type = 'ConstMap';
+
+    function ConstEntry(key, value) {
+        this.key = key;
+        this.value = value;
+    }
+    ConstEntry.prototype.type = 'ConstEntry';
+
     function Struct(id, fields, annotations) {
         this.id = id;
         this.fields = fields;
@@ -264,14 +280,18 @@ ConstValue
 
 ConstList
   = '[' __ values:(v:ConstValue __ ListSeparator? __ { return v} )* ']' __ {
-    return values
+    return new ConstList(values);
   }
 
 ConstMap
-  = '{' __ (ConstValuePair)* '}' __
+  = '{' __ entries:(ConstValueEntry)* '}' __ {
+    return new ConstMap(entries);
+  }
 
-ConstValuePair
-  = k:ConstValue __ ':' __ v:ConstValue __ ListSeparator?
+ConstValueEntry
+  = k:ConstValue __ ':' __ v:ConstValue __ ListSeparator? {
+    return new ConstEntry(k, v);
+  }
 
 Struct
   = 'struct' __ id:Identifier xsdAll? __ '{' __ fs:Field* __ '}' __ ta:TypeAnnotations? {
@@ -603,7 +623,9 @@ HexDigit
 
 NumberLiteral 'number'
   = HexIntegerLiteral
-  / [+-]? DecimalLiteral
+  / [+-]? i:DecimalLiteral {
+    return i;
+  }
   / SignedInteger
 
 DecimalLiteral 'decimal literal'

--- a/thrift-idl.pegjs
+++ b/thrift-idl.pegjs
@@ -108,7 +108,6 @@
         this.id = id;
         this.returns = ft;
         this.fields = fields;
-        this.fields.isArgument = true;
         this.throws = _throws;
         this.annotations = annotations;
     }

--- a/thrift-idl.pegjs
+++ b/thrift-idl.pegjs
@@ -116,19 +116,22 @@
     }
     FieldIdentifier.prototype.type = 'FieldIdentifier';
 
-    function MapType(keyType, valueType) {
+    function MapType(keyType, valueType, annotations) {
         this.keyType = keyType;
         this.valueType = valueType;
+        this.annotations = annotations;
     }
     MapType.prototype.type = 'Map';
 
-    function SetType(valueType) {
+    function SetType(valueType, annotations) {
         this.valueType = valueType;
+        this.annotations = annotations;
     }
     SetType.prototype.type = 'Set';
 
-    function ListType(valueType) {
+    function ListType(valueType, annotations) {
         this.valueType = valueType;
+        this.annotations = annotations;
     }
     ListType.prototype.type = 'List';
 
@@ -378,12 +381,12 @@ MapType
   = 'map' __ cppType? '<' __ ft1:FieldType __ ',' __ ft2:FieldType __ '>'
     __ ta:TypeAnnotations?
   {
-    return new MapType(ft1, ft2);
+    return new MapType(ft1, ft2, ta);
   }
 
 SetType
   = 'set' __ cppType? '<' __ ft:FieldType __ '>' __ ta:TypeAnnotations? {
-    return new SetType(ft);
+    return new SetType(ft, ta);
   }
 
 // It's weird, and probably an error, but the original thrift yacc
@@ -393,7 +396,7 @@ SetType
 
 ListType
   = 'list' __ '<' __ ft:FieldType __ '>' __ ta:TypeAnnotations? cppType? {
-    return new ListType(ft);
+    return new ListType(ft, ta);
   }
 
 cppType

--- a/thrift-idl.pegjs
+++ b/thrift-idl.pegjs
@@ -20,7 +20,7 @@
     Namespace.prototype.type = 'Namespace';
 
     function Typedef(type, id, annotations) {
-        this.typedefType = type;
+        this.valueType = type;
         this.id = id;
         this.annotations = annotations;
     }

--- a/thrift-idl.pegjs
+++ b/thrift-idl.pegjs
@@ -34,7 +34,7 @@
 
     function Enum(id, definitions, annotations) {
         this.id = id;
-        this.enumDefinitions = definitions;
+        this.definitions = definitions;
         this.annotations = annotations;
     }
     Enum.prototype.type = 'Enum';
@@ -44,6 +44,7 @@
         this.value = value;
         this.annotations = annotations;
     }
+    EnumDefinition.prototype.fieldType = new BaseType('i32');
     EnumDefinition.prototype.type = 'EnumDefinition';
 
     function Senum(id, definitions, annotations) {
@@ -253,7 +254,7 @@ Enum
   }
 
 EnumDefinition
-  = id:Identifier value:('=' __ v:IntConstant { return v.value })? __ ta:TypeAnnotations? ListSeparator? __ {
+  = id:Identifier value:('=' __ v:IntConstant { return v })? __ ta:TypeAnnotations? ListSeparator? __ {
     return new EnumDefinition(id, value, ta);
   }
 

--- a/typedef.js
+++ b/typedef.js
@@ -20,31 +20,25 @@
 
 'use strict';
 
-require('./binary');
-require('./boolean');
-require('./byte');
-require('./double');
-require('./i16');
-require('./i32');
-require('./i64');
-require('./specmap-entries');
-require('./thrift-idl');
-require('./specmap-obj');
-require('./string');
-require('./tlist');
-require('./tmap');
-require('./tstruct');
-require('./void');
-require('./skip');
-require('./struct');
-require('./struct-skip');
-require('./exception');
-require('./service');
-require('./spec');
-require('./list');
-require('./set');
-require('./map');
-require('./typedef');
-require('./const');
-require('./default');
-require('./enum');
+function TypedefSpec() {
+    var self = this;
+    self.name = null;
+    self.valueDefinition = null;
+    self.to = null;
+}
+
+TypedefSpec.prototype.compile = function compile(def, spec) {
+    var self = this;
+    self.name = def.id.name;
+    self.valueDefinition = def.valueType;
+};
+
+TypedefSpec.prototype.link = function link(spec) {
+    var self = this;
+    if (!self.to) {
+        self.to = spec.resolve(self.valueDefinition);
+    }
+    return self.to;
+};
+
+module.exports.TypedefSpec = TypedefSpec;

--- a/void.js
+++ b/void.js
@@ -29,6 +29,7 @@ function VoidSpec() {
 }
 
 VoidSpec.prototype.rw = VoidRW;
+VoidSpec.prototype.name = 'void';
 VoidSpec.prototype.typeid = TYPE.VOID;
 
 module.exports.VoidRW = VoidRW;


### PR DESCRIPTION
This is now a tracking WIP for work spinning out of these changes.

- [x] #14 Assimilate Thrift IDL parser
- [x] #16 Implement base types (`base_types` branch)
  - [x] #17 Implement skip reader for eliding unknown fields of structs (`skip` branch)
    - [x] #37  Integration tests for skip reader on structs (`struct-skip` branch)
  - [x] #19 MapSpec (`map` branch)
  - [x] #21 ListSpec (`list` branch)
    - [x] #20 SetSpec (`set` branch)
  - [x] #22 StructSpec (`struct` branch)
    - [x] #26 ExceptionSpec (`exception` branch)
      - [x] #27 ServiceSpec and Spec (`spec` branch) :tada:
    - [x] strict mode (all fields must be marked optional or required) (`strict`)
    - [x] #32 forward and cyclic reference test (`spec`)
    - [x] #34 TypedefSpec
    - [x] #36 consts
      - [x] #38 default values
      - [x] #40 enums

This is a WIP that subsumes the Spec concept from Thriftify.

Thrift IDL gets turned into an AST. The AST gets turned into a Spec of Specs in two passes. In the first pass, specs are created for each type definition. In the second, the fields of structs are linked to the specs they refer to. Forward and cyclic references are possible because of the two-pass approach.

The Spec has a constructor function for each Struct, and each Struct has a custom RW object. The RW bypasses the intermediate object format entirely. Unknown properties of structs are skipped without creating the objects they represent, using the skip reader.