### PR TITLE
MapSpec

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -88,6 +88,12 @@ module.exports.FieldRequiredError = TypedError({
     what: null
 });
 
+module.exports.UnexpectedMapTypeAnnotation = TypedError({
+    type: 'thrift-unexpected-map-type-annotation',
+    message: 'unexpected map js.type annotation "{mapType}"',
+    mapType: null
+});
+
 module.exports.InvalidEnumerationTypeError = TypedError({
     type: 'thrift-invalid-enumeration-type',
     message: 'name must be a string for enumeration {enumName}, got: {name} ({nameType})',

--- a/map.js
+++ b/map.js
@@ -20,30 +20,31 @@
 
 'use strict';
 
-require('./binary');
-require('./boolean');
-require('./byte');
-require('./double');
-require('./i16');
-require('./i32');
-require('./i64');
-require('./specmap-entries');
-require('./thrift-idl');
-require('./specmap-obj');
-require('./string');
-require('./tlist');
-require('./tmap');
-require('./tstruct');
-require('./void');
-require('./skip');
-require('./struct');
-require('./struct-skip');
-require('./exception');
-require('./service');
-require('./spec');
-require('./list');
-require('./set');
-require('./map');
-require('./const');
-require('./default');
-require('./enum');
+var TYPE = require('./TYPE');
+var SpecMapObjRW = require('./specmap-obj').SpecMapObjRW;
+var SpecMapEntriesRW = require('./specmap-entries').SpecMapEntriesRW;
+var UnexpectedMapTypeAnnotation = require('./errors').UnexpectedMapTypeAnnotation; // TODO
+
+var none = {};
+
+function MapSpec(keyType, valueType, annotations) {
+    var self = this;
+
+    annotations = annotations || none;
+    var type = annotations['js.type'] || 'object';
+
+    if (type === 'object') {
+        self.rw = new SpecMapObjRW(keyType, valueType);
+    } else if (type === 'entries') {
+        self.rw = new SpecMapEntriesRW(keyType, valueType);
+    } else {
+        throw UnexpectedMapTypeAnnotation({
+            mapType: type
+        });
+    }
+}
+
+MapSpec.prototype.name = 'map';
+MapSpec.prototype.typeid = TYPE.MAP;
+
+module.exports.MapSpec = MapSpec;

--- a/spec.js
+++ b/spec.js
@@ -42,7 +42,7 @@ var I64Spec = require('./i64').I64Spec;
 var DoubleSpec = require('./double').DoubleSpec;
 var ListSpec = require('./list').ListSpec;
 var SetSpec = require('./set').SetSpec;
-// TODO var MapSpec = require('./map').MapSpec;
+var MapSpec = require('./map').MapSpec;
 var ConstSpec = require('./const').ConstSpec;
 
 function Spec(options) {
@@ -216,6 +216,8 @@ Spec.prototype.resolve = function resolve(def) {
         return new ListSpec(self.resolve(def.valueType), def.annotations);
     } else if (def.type === 'Set') {
         return new SetSpec(self.resolve(def.valueType), def.annotations);
+    } else if (def.type === 'Map') {
+        return new MapSpec(self.resolve(def.keyType), self.resolve(def.valueType), def.annotations);
     } else {
         err = new Error(util.format('Can\'t get reader/writer for definition with unknown type %s', def.type));
     }

--- a/test/map.js
+++ b/test/map.js
@@ -1,0 +1,179 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
+var path = require('path');
+var fs = require('fs');
+var MapSpec = require('../map').MapSpec;
+var Spec = require('../spec');
+var spec;
+
+var StringSpec = require('../string').StringSpec;
+var I16Spec = require('../i16').I16Spec;
+
+test('spec parses', function t(assert) {
+    var filename = path.join(__dirname, 'map.thrift');
+    var source = fs.readFileSync(filename, 'ascii');
+    spec = new Spec({source: source});
+    spec.getType('Graph');
+    assert.pass('spec parses');
+    assert.end();
+});
+
+var strI16Map = new MapSpec(new StringSpec(), new I16Spec(), {});
+test('MapSpec: strI16MapRW', testRW.cases(strI16Map.rw, [
+    [{}, [
+        0x0b,                  // key_type:1 -- 11, string
+        0x06,                  // val_type:1 -- 6, i16
+        0x00, 0x00, 0x00, 0x00 // length:4   -- 0
+    ]],
+
+    [{
+        'abc': 1,
+        'def': 2,
+        'ghi': 3
+    }, [
+        0x0b,                   // key_type:1 -- 11, string
+        0x06,                   // val_type:1 -- 6, i16
+        0x00, 0x00, 0x00, 0x03, // length:4   -- 3
+                                //            --
+        0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
+        0x61, 0x62, 0x63,       // chars      -- "abc"
+        0x00, 0x01,             // Int16BE    -- 1
+                                //            --
+        0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
+        0x64, 0x65, 0x66,       // chars      -- "def"
+        0x00, 0x02,             // Int16BE    -- 2
+                                //            --
+        0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
+        0x67, 0x68, 0x69,       // chars      -- "ghi"
+        0x00, 0x03              // Int16BE    -- 3
+    ]],
+
+    {
+        readTest: {
+            bytes: [
+                0x09,                  // key_type:1 -- 9
+                0x02,                  // val_type:1 -- 2
+                0x00, 0x00, 0x00, 0x00 // length:4   -- 0
+            ],
+            error: {
+                type: 'thrift-map-key-typeid-mismatch',
+                name: 'ThriftMapKeyTypeidMismatchError',
+                message: 'encoded map key typeid 9 doesn\'t match expected ' +
+                         'type "string" (id: 11)'
+            }
+        }
+    },
+
+    {
+        readTest: {
+            bytes: [
+                0x0b,                  // key_type:1 -- 11
+                0x09,                  // val_type:1 -- 9
+                0x00, 0x00, 0x00, 0x00 // length:4   -- 0
+            ],
+            error: {
+                type: 'thrift-map-val-typeid-mismatch',
+                name: 'ThriftMapValTypeidMismatchError',
+                message: 'encoded map value typeid 9 doesn\'t match expected ' +
+                         'type "i16" (id: 6)'
+            }
+        }
+    }
+
+]));
+
+var strI16MapEntries = new MapSpec(new StringSpec(), new I16Spec(), {'js.type': 'entries'});
+test('MapSpec: strI16MapRW', testRW.cases(strI16MapEntries.rw, [
+    [[], [
+        0x0b,                  // key_type:1 -- 11, string
+        0x06,                  // val_type:1 -- 6, i16
+        0x00, 0x00, 0x00, 0x00 // length:4   -- 0
+    ]],
+
+    [[
+        ['abc', 1],
+        ['def', 2],
+        ['ghi', 3]
+    ], [
+        0x0b,                   // key_type:1 -- 11, string
+        0x06,                   // val_type:1 -- 6, i16
+        0x00, 0x00, 0x00, 0x03, // length:4   -- 3
+                                //            --
+        0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
+        0x61, 0x62, 0x63,       // chars      -- "abc"
+        0x00, 0x01,             // Int16BE    -- 1
+                                //            --
+        0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
+        0x64, 0x65, 0x66,       // chars      -- "def"
+        0x00, 0x02,             // Int16BE    -- 2
+                                //            --
+        0x00, 0x00, 0x00, 0x03, // str_len:4  -- 3
+        0x67, 0x68, 0x69,       // chars      -- "ghi"
+        0x00, 0x03              // Int16BE    -- 3
+    ]],
+
+    {
+        readTest: {
+            bytes: [
+                0x09,                  // key_type:1 -- 9
+                0x02,                  // val_type:1 -- 2
+                0x00, 0x00, 0x00, 0x00 // length:4   -- 0
+            ],
+            error: {
+                type: 'thrift-map-key-typeid-mismatch',
+                name: 'ThriftMapKeyTypeidMismatchError',
+                message: 'encoded map key typeid 9 doesn\'t match expected ' +
+                         'type "string" (id: 11)'
+            }
+        }
+    },
+
+    {
+        readTest: {
+            bytes: [
+                0x0b,                  // key_type:1 -- 11
+                0x09,                  // val_type:1 -- 9
+                0x00, 0x00, 0x00, 0x00 // length:4   -- 0
+            ],
+            error: {
+                type: 'thrift-map-val-typeid-mismatch',
+                name: 'ThriftMapValTypeidMismatchError',
+                message: 'encoded map value typeid 9 doesn\'t match expected ' +
+                         'type "i16" (id: 6)'
+            }
+        }
+    }
+
+]));
+
+test('invalid map type annotation', function t(assert) {
+    try {
+        var graphSpec = new Spec({source: 'struct Graph { 1: required map<byte, byte> (js.type = "bogus") edges }'});
+        assert.ok(!graphSpec, 'should not parse');
+    } catch (err) {
+        assert.equals(err.message, 'unexpected map js.type annotation "bogus"', 'error message');
+    }
+    assert.end();
+});

--- a/test/map.thrift
+++ b/test/map.thrift
@@ -1,0 +1,3 @@
+struct Graph {
+    1: required map<string, i16> edges
+}


### PR DESCRIPTION
This is intended to put a Spec face on the Entries and Object MapRW that @jcorbin has already landed. We just need a test to puppeteer the MapSpec constructor based on annotation options.

- [x] To do so, we should use the base type specs in #16 
- [x] Name the specs, for already implemented RW errors
- [x] Thread type annotations for maps, sets, and lists through the parser
- [x] Test