### PR TITLE
SetSpec

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
     "rules": {
         "max-len": [1, 120],
+        "max-statements": [1, 30],
         "curly": 0
     }
 }

--- a/errors.js
+++ b/errors.js
@@ -22,13 +22,14 @@
 
 var TypedError = require('error/typed');
 
-module.exports.ListTypeIdMismatch = TypedError({
-    type: 'thrift-list-typeid-mismatch',
-    message: 'encoded list typeid {encoded} doesn\'t match ' +
+module.exports.TypeIdMismatch = TypedError({
+    type: 'thrift-typeid-mismatch',
+    message: 'encoded {what} typeid {encoded} doesn\'t match ' +
         'expected type "{expected}" (id: {expectedId})',
     encoded: null,
     expected: null,
-    expectedId: null
+    expectedId: null,
+    what: null
 });
 
 module.exports.MapKeyTypeIdMismatch = TypedError({

--- a/index.js
+++ b/index.js
@@ -75,6 +75,7 @@ module.exports.I64Spec = require('./i64').I64Spec;
 
 module.exports.ListRW = require('./list').ListRW;
 module.exports.ListSpec = require('./list').ListSpec;
+module.exports.SetSpec = require('./set').SetSpec;
 
 module.exports.SpecMapObjRW = require('./specmap-obj').SpecMapObjRW;
 module.exports.SpecMapEntriesRW = require('./specmap-entries').SpecMapEntriesRW;

--- a/set.js
+++ b/set.js
@@ -1,0 +1,112 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var util = require('util');
+var assert = require('assert');
+var ListSpec = require('./list').ListSpec;
+
+function SetSpec(valueType, annotations) {
+    var self = this;
+    ListSpec.call(self, valueType, annotations);
+    self.mode = annotations && annotations['js.type'] || 'array';
+    if (self.mode === 'object') {
+        if (valueType.name === 'string') {
+            self.rw.form = self.objectStringForm;
+        // istanbul ignore else
+        } else if (
+            valueType.name === 'byte' ||
+            valueType.name === 'i16' ||
+            valueType.name === 'i32'
+        ) {
+            self.rw.form = self.objectNumberForm;
+        } else {
+            assert.fail('sets with js.type of \'object\' must have a value type ' +
+                'of \'string\', \'byte\', \'i16\', or \'i32\'');
+        }
+    // istanbul ignore else
+    } else if (self.mode === 'array') {
+        self.rw.form = self.arrayForm;
+    } else {
+        assert.fail('set must have js.type of object or array (default)');
+    }
+}
+
+util.inherits(SetSpec, ListSpec);
+
+SetSpec.prototype.name = 'set';
+
+SetSpec.prototype.arrayForm = {
+    create: function create() {
+        return [];
+    },
+    add: function add(values, value) {
+        values.push(value);
+    },
+    toArray: function toArray(values) {
+        assert(Array.isArray(values), 'set must be expressed as an array');
+        return values;
+    }
+};
+
+SetSpec.prototype.objectNumberForm = {
+    create: function create() {
+        return {};
+    },
+    add: function add(values, value) {
+        values[value] = true;
+    },
+    toArray: function toArray(object) {
+        assert(object && typeof object === 'object', 'set must be expressed as an object');
+        var keys = Object.keys(object);
+        var values = [];
+        for (var index = 0; index < keys.length; index++) {
+            // istanbul ignore else
+            if (object[keys[index]]) {
+                values.push(+keys[index]);
+            }
+        }
+        return values;
+    }
+};
+
+SetSpec.prototype.objectStringForm = {
+    create: function create() {
+        return {};
+    },
+    add: function add(values, value) {
+        values[value] = true;
+    },
+    toArray: function toArray(object) {
+        assert(object && typeof object === 'object', 'set must be expressed as an object');
+        var keys = Object.keys(object);
+        var values = [];
+        for (var index = 0; index < keys.length; index++) {
+            // istanbul ignore else
+            if (object[keys[index]]) {
+                values.push(keys[index]);
+            }
+        }
+        return values;
+    }
+};
+
+module.exports.SetSpec = SetSpec;

--- a/spec.js
+++ b/spec.js
@@ -40,7 +40,7 @@ var I32Spec = require('./i32').I32Spec;
 var I64Spec = require('./i64').I64Spec;
 var DoubleSpec = require('./double').DoubleSpec;
 var ListSpec = require('./list').ListSpec;
-// TODO var SetSpec = require('./set').SetSpec;
+var SetSpec = require('./set').SetSpec;
 // TODO var MapSpec = require('./map').MapSpec;
 
 function Spec(args) {
@@ -188,6 +188,8 @@ Spec.prototype.resolve = function resolve(def) {
         return self.types[def.name];
     } else if (def.type === 'List') {
         return new ListSpec(self.resolve(def.valueType), def.annotations);
+    } else if (def.type === 'Set') {
+        return new SetSpec(self.resolve(def.valueType), def.annotations);
     } else {
         err = new Error(util.format('Can\'t get reader/writer for definition with unknown type %s', def.type));
     }

--- a/test/index.js
+++ b/test/index.js
@@ -42,3 +42,4 @@ require('./exception');
 require('./service');
 require('./spec');
 require('./list');
+require('./set');

--- a/test/list.js
+++ b/test/list.js
@@ -52,8 +52,8 @@ test('ListSpec.rw: list of bytes', testRW.cases(byteList.rw, [
                 0x00, 0x00, 0x00, 0x00 // length:4 -- 0
             ],
             error: {
-                type: 'thrift-list-typeid-mismatch',
-                name: 'ThriftListTypeidMismatchError',
+                type: 'thrift-typeid-mismatch',
+                name: 'ThriftTypeidMismatchError',
                 message: 'encoded list typeid 43 doesn\'t match expected ' +
                          'type "byte" (id: 3)'
             }

--- a/test/set.js
+++ b/test/set.js
@@ -1,0 +1,164 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var test = require('tape');
+var testRW = require('bufrw/test_rw');
+var fs = require('fs');
+var path = require('path');
+
+var Spec = require('../spec');
+var SetSpec = require('../set').SetSpec;
+var StringSpec = require('../string').StringSpec;
+var ByteSpec = require('../byte').ByteSpec;
+
+var byteSet = new SetSpec(new ByteSpec());
+var stringSet = new SetSpec(new StringSpec());
+var stringObjectSet = new SetSpec(new StringSpec(), {'js.type': 'object'});
+
+test('SetSpec.rw: set of bytes', testRW.cases(byteSet.rw, [
+
+    [[], [
+        0x03,                  // type:1   -- 3, BYTE
+        0x00, 0x00, 0x00, 0x00 // length:4 -- 0
+    ]],
+
+    [[1, 2, 3], [
+        0x03,                   // type:1   -- 3, BYTE
+        0x00, 0x00, 0x00, 0x03, // length:4 -- 3
+        0x01,                   // byte:1   -- 1
+        0x02,                   // byte:1   -- 2
+        0x03                    // byte:1   -- 3
+    ]],
+
+    {
+        readTest: {
+            bytes: [
+                0x2b,                  // type:1
+                0x00, 0x00, 0x00, 0x00 // length:4 -- 0
+            ],
+            error: {
+                type: 'thrift-typeid-mismatch',
+                name: 'ThriftTypeidMismatchError',
+                message: 'encoded set typeid 43 doesn\'t match expected ' +
+                         'type "byte" (id: 3)'
+            }
+        }
+    },
+
+    {
+        readTest: {
+            bytes: [
+                0x03,                  // type:1   -- 3, BYTE
+                0xff, 0xff, 0xff, 0xff // length:4 -- -1
+            ],
+            error: {
+                type: 'thrift-invalid-size',
+                name: 'ThriftInvalidSizeError',
+                message: 'invalid size -1 of set; expects non-negative number'
+            }
+        }
+    }
+
+]));
+
+test('SetSpec.rw: set of strings', testRW.cases(stringSet.rw, [
+
+    [[], [
+        0x0b,                  // type:1   -- 11, STRING
+        0x00, 0x00, 0x00, 0x00 // length:4 -- 0
+    ]],
+
+    [['a', 'ab', 'abc'], [
+        0x0b,                    // type:1    -- 11, STRING
+        0x00, 0x00, 0x00, 0x03,  // length:4  -- 3
+        0x00, 0x00, 0x00, 0x01,  // str_len:4 -- 1
+        0x61,                    // chars     -- "a"
+        0x000, 0x00, 0x00, 0x02, // str_len:4 -- 1
+        0x61, 0x62,              // chars     -- "ab"
+        0x00, 0x00, 0x00, 0x03,  // str_len:4 -- 1
+        0x61, 0x62, 0x63         // chars     -- "abc"
+    ]]
+
+]));
+
+test('SetSpec.rw: set of strings as object', testRW.cases(stringObjectSet.rw, [
+
+    [{}, [
+        0x0b,                  // type:1   -- 11, STRING
+        0x00, 0x00, 0x00, 0x00 // length:4 -- 0
+    ]],
+
+    [{a: true, ab: true, abc: true}, [
+        0x0b,                    // type:1    -- 11, STRING
+        0x00, 0x00, 0x00, 0x03,  // length:4  -- 3
+        0x00, 0x00, 0x00, 0x01,  // str_len:4 -- 1
+        0x61,                    // chars     -- "a"
+        0x000, 0x00, 0x00, 0x02, // str_len:4 -- 1
+        0x61, 0x62,              // chars     -- "ab"
+        0x00, 0x00, 0x00, 0x03,  // str_len:4 -- 1
+        0x61, 0x62, 0x63         // chars     -- "abc"
+    ]]
+
+]));
+
+var source = fs.readFileSync(path.join(__dirname, 'set.thrift'), 'ascii');
+var spec = new Spec({source: source});
+
+test('Struct with set rw', testRW.cases(spec.Bucket.rw, [
+
+    [new spec.Bucket({asArray: [1, 2, 3]}), [
+        0x0f,                   // type:1      -- 15, struct
+        0x00, 0x01,             // field:2     -- 1, asArray
+        0x08,                   // type:1      -- 8, i32
+        0x00, 0x00, 0x00, 0x03, // len:4       -- 3
+        0x00, 0x00, 0x00, 0x01, // [0] value:4 -- 1
+        0x00, 0x00, 0x00, 0x02, // [1] value:4 -- 2
+        0x00, 0x00, 0x00, 0x03, // [2] value:4 -- 3
+        0x00                    // type:1      -- 0, stop
+    ]],
+
+    [new spec.Bucket({numbersAsObject: {1: true, 2: true, 3: true}}), [
+        0x0f,                   // type:1      -- 15, struct
+        0x00, 0x02,             // field:2     -- 1, numbersAsObject
+        0x08,                   // type:1      -- 8, i32
+        0x00, 0x00, 0x00, 0x03, // len:4       -- 3
+        0x00, 0x00, 0x00, 0x01, // [0] value:4 -- 1
+        0x00, 0x00, 0x00, 0x02, // [1] value:4 -- 2
+        0x00, 0x00, 0x00, 0x03, // [2] value:4 -- 3
+        0x00                    // type:1      -- 0, stop
+    ]],
+
+    [new spec.Bucket({stringsAsObject: {1: true, 2: true, 3: true}}), [
+        0x0f,                   // type:1       -- 15, struct
+        0x00, 0x03,             // field:2      -- 1, numbersAsObject
+        0x0b,                   // type:1       -- 11, string
+        0x00, 0x00, 0x00, 0x03, // length:4     -- 3
+        0x00, 0x00, 0x00, 0x01, // [0] length:4 -- 1
+        0x31,                   // [0] value:1  -- '1'
+        0x00, 0x00, 0x00, 0x01, // [1] length:4 -- 1
+        0x32,                   // [1] value:1  -- '2'
+        0x00, 0x00, 0x00, 0x01, // [2] length:4 -- 1
+        0x33,                   // [2] value:1  -- '3'
+        0x00                    // type:1       -- 0, stop
+    ]]
+
+]));

--- a/test/set.thrift
+++ b/test/set.thrift
@@ -1,0 +1,5 @@
+struct Bucket {
+    1: optional set<i32> asArray
+    2: optional set<i32> (js.type = 'object') numbersAsObject
+    3: optional set<string> (js.type = 'object') stringsAsObject
+}


### PR DESCRIPTION
This is a WIP branch that introduces ListRW and ListSpec. The functionality overlaps somewhat with TList and SpecList, so that needs to get consolidated. The Thrift IDL will eventually drive the Spec interfaces. I’ve coded this in a way that the SetSpec just inherits ListSpec, but can eventually override how it constructs and adds to sets. Or we can copypasta for perf. Options are open.

TODO

- [x] land #16 base types as a basis for testing
- [x] land #21 for ListSpec basis
- [x] test this, perhaps consolidating test/speclist