### PR TITLE
Implement Spec and ServiceSpec

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
     "rules": {
+        "max-len": [1, 120],
         "curly": 0
     }
 }

--- a/service.js
+++ b/service.js
@@ -1,0 +1,103 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var StructSpec = require('./struct').StructSpec;
+
+function FunctionSpec(args) {
+    var self = this;
+    self.name = args.name;
+    self.service = args.service;
+    self.fullName = self.service.name + '::' + self.name;
+    self.spec = args.spec;
+    self.args = null;
+    self.result = null;
+    self.strict = args.strict;
+}
+
+FunctionSpec.prototype.compile = function process(def, spec) {
+    var self = this;
+
+    self.name = def.id.name;
+
+    self.args = new StructSpec({strict: self.strict});
+    self.args = spec.compileStruct({
+        id: {name: self.name + '_args', as: self.fullName + '_args'},
+        fields: def.fields
+    });
+
+    var resultFields = def.throws || [];
+    resultFields.unshift({ // TODO use Field constructor from pegjs...somehow
+        id: 0,
+        name: 'success',
+        valueType: def.returns,
+        required: true,
+        optional: false,
+        annotations: null
+    });
+
+    self.result = spec.compileStruct({
+        id: {name: self.name + '_result', as: self.fullName + '_result'},
+        fields: resultFields
+    });
+};
+
+FunctionSpec.prototype.link = function link(spec) {
+    var self = this;
+    self.args.link(spec);
+    self.result.link(spec);
+};
+
+function ServiceSpec(args) {
+    var self = this;
+    self.name = null;
+    self.functions = [];
+    self.strict = args.strict;
+}
+
+ServiceSpec.prototype.compile = function process(def, spec) {
+    var self = this;
+    self.name = def.id.name;
+    for (var index = 0; index < def.functions.length; index++) {
+        self.compileFunction(def.functions[index], spec);
+    }
+};
+
+ServiceSpec.prototype.compileFunction = function processFunction(def, spec) {
+    var self = this;
+    var functionSpec = new FunctionSpec({
+        name: def.id.name,
+        service: self,
+        strict: self.strict
+    });
+    functionSpec.compile(def, spec);
+    self.functions.push(functionSpec);
+};
+
+ServiceSpec.prototype.link = function link(spec) {
+    var self = this;
+    for (var index = 0; index < self.functions.length; index++) {
+        self.functions[index].link(spec);
+    }
+};
+
+module.exports.FunctionSpec = FunctionSpec;
+module.exports.ServiceSpec = ServiceSpec;

--- a/spec.js
+++ b/spec.js
@@ -1,0 +1,176 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var assert = require('assert');
+var util = require('util');
+var idl = require('./thrift-idl');
+var Result = require('bufrw/result');
+
+var ServiceSpec = require('./service').ServiceSpec;
+var StructSpec = require('./struct').StructSpec;
+// TODO var ExceptionSpec = require('./exception').ExceptionSpec;
+// TODO var EnumSpec = require('./enum').EnumSpec;
+
+var VoidSpec = require('./void').VoidSpec;
+var BooleanSpec = require('./boolean').BooleanSpec;
+var StringSpec = require('./string').StringSpec;
+var BinarySpec = require('./string').BinarySpec;
+var ByteSpec = require('./byte').ByteSpec;
+var I16Spec = require('./i16').I16Spec;
+var I32Spec = require('./i32').I32Spec;
+var I64Spec = require('./i64').I64Spec;
+var DoubleSpec = require('./double').DoubleSpec;
+// TODO var ListSpec = require('./list').ListSpec;
+// TODO var SetSpec = require('./set').SetSpec;
+// TODO var MapSpec = require('./map').MapSpec;
+
+function Spec(args) {
+    var self = this;
+
+    assert(args, 'args required');
+    assert(typeof args === 'object', 'args must be object');
+    assert(args.source, 'source required');
+    assert(typeof args.source === 'string', 'source must be string');
+
+    self.strict = args.strict || false;
+
+    // type specs, including structs, exceptions, typedefs, unions, services
+    self.types = Object.create(null);
+    // TODO consts, enum values
+
+    // Two passes permits forward references and cyclic references.
+    // First pass constructs objects.
+    self.compile(args.source);
+    // Second pass links field references of structs.
+    self.link();
+}
+
+Spec.prototype.getType = function getType(name) {
+    var self = this;
+    return self.getTypeResult(name).toValue();
+};
+
+Spec.prototype.getTypeResult = function getType(name) {
+    var self = this;
+    var type = self.types[name];
+    if (!type) {
+        return new Result(new Error(util.format('type %s not found', name)));
+    }
+    return new Result(null, type);
+};
+
+Spec.prototype.baseTypes = {
+    void: VoidSpec,
+    bool: BooleanSpec,
+    byte: ByteSpec,
+    i16: I16Spec,
+    i32: I32Spec,
+    i64: I64Spec,
+    double: DoubleSpec,
+    string: StringSpec,
+    binary: BinarySpec
+};
+
+Spec.prototype.compile = function compile(source) {
+    var self = this;
+    var syntax = idl.parse(source);
+    assert.equal(syntax.type, 'Program', 'expected a program');
+    self.compileDefinitions(syntax.definitions);
+};
+
+Spec.prototype.compileType = function compileType(def, type) {
+    var self = this;
+    var name = def.as || def.name;
+    assert(!self.types[name], 'duplicate reference to ' + def.name + ' at ' + def.line + ':' + def.column);
+    self.types[name] = type;
+    self[name] = type;
+};
+
+Spec.prototype._definitionProcessors = {
+    // sorted
+    // TODO Const: 'compileConst',
+    // TODO Enum: 'compileEnum',
+    // TODO Exception: 'compileException',
+    // TODO Senum: 'compileSenum',
+    Service: 'compileService',
+    Struct: 'compileStruct'
+    // TODO Typedef: 'compileTypedef',
+    // TODO Union: 'compileUnion'
+};
+
+Spec.prototype.compileDefinitions = function compileDefinitions(defs) {
+    var self = this;
+    for (var index = 0; index < defs.length; index++) {
+        var def = defs[index];
+        // istanbul ignore else
+        if (self._definitionProcessors[def.type]) {
+            self[self._definitionProcessors[def.type]](def);
+        }
+    }
+};
+
+Spec.prototype.compileStruct = function compileStruct(def) {
+    var self = this;
+    var spec = new StructSpec({strict: self.strict});
+    spec.compile(def, self);
+    self.compileType(def.id, spec);
+    self.types[spec.name] = spec;
+    return spec;
+};
+
+Spec.prototype.compileService = function compileService(def, spec) {
+    var self = this;
+    var service = new ServiceSpec({strict: self.strict});
+    service.compile(def, self);
+    self.compileType(def.id, service);
+};
+
+Spec.prototype.link = function link() {
+    var self = this;
+    var index;
+    var typeNames = Object.keys(self.types);
+    for (index = 0; index < typeNames.length; index++) {
+        var type = self.types[typeNames[index]];
+        type.link(self);
+    }
+};
+
+Spec.prototype.resolve = function resolve(def) {
+    var self = this;
+    var err;
+    if (def.type === 'BaseType') {
+        return new self.baseTypes[def.baseType](def.annotations);
+    // istanbul ignore else
+    } else if (def.type === 'Identifier') {
+        if (!self.types[def.name]) {
+            err = new Error('cannot resolve reference to ' + def.name + ' at ' + def.line + ':' + def.column);
+            err.line = def.line;
+            err.column = def.column;
+            throw err;
+        }
+        return self.types[def.name];
+    } else {
+        err = new Error(util.format('Can\'t get reader/writer for definition with unknown type %s', def.type));
+    }
+};
+
+module.exports = Spec;

--- a/struct.js
+++ b/struct.js
@@ -35,8 +35,8 @@ var ReadResult = bufrw.ReadResult;
 
 function FieldSpec(def) {
     var self = this;
-    self.id = def.id;
-    self.name = def.name;
+    self.id = def.fieldId;
+    self.name = def.id.name;
     self.required = def.required;
     self.optional = def.optional;
     self.annotations = def.annotations;
@@ -73,7 +73,7 @@ StructSpec.prototype.compile = function compile(def) {
     var self = this;
     // Struct names must be valid JavaScript. If the Thrift name is not valid
     // in JavaScript, it can be overridden with the js.name annotation.
-    self.name = def.annotations && def.annotations['js.name'] || def.name;
+    self.name = def.annotations && def.annotations['js.name'] || def.id.name;
     self.isArgument = def.isArgument;
     var fields = def.fields;
     for (var index = 0; index < fields.length; index++) {

--- a/test/service.js
+++ b/test/service.js
@@ -20,23 +20,15 @@
 
 'use strict';
 
-require('./binary');
-require('./boolean');
-require('./byte');
-require('./double');
-require('./i16');
-require('./i32');
-require('./i64');
-require('./speclist');
-require('./specmap-entries');
-require('./thrift-idl');
-require('./specmap-obj');
-require('./string');
-require('./tlist');
-require('./tmap');
-require('./tstruct');
-require('./void');
-require('./skip');
-require('./struct');
-require('./service');
-require('./spec');
+var test = require('tape');
+
+var Spec = require('../spec');
+var fs = require('fs');
+var path = require('path');
+var source = fs.readFileSync(path.join(__dirname, 'service.thrift'), 'ascii');
+var spec = new Spec({source: source});
+
+test('has args', function t(assert) {
+    assert.ok(spec.getType('Foo::foo_args'), 'has args');
+    assert.end();
+});

--- a/test/service.thrift
+++ b/test/service.thrift
@@ -1,0 +1,7 @@
+
+service Foo {
+    byte foo(0: byte number) throws (
+        1: string bad
+    )
+}
+

--- a/test/spec-duplicate-error.thrift
+++ b/test/spec-duplicate-error.thrift
@@ -1,0 +1,5 @@
+service Service {
+}
+
+service Service {
+}

--- a/test/spec-reference-error.thrift
+++ b/test/spec-reference-error.thrift
@@ -1,0 +1,4 @@
+service Service {
+    // The following line contains two invalid references.
+    Struct foo(0: Struct bar)
+}

--- a/test/spec.js
+++ b/test/spec.js
@@ -1,0 +1,91 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var test = require('tape');
+var Spec = require('../spec');
+
+var spec;
+
+test('spec parses', function t(assert) {
+    var filename = path.join(__dirname, 'spec.thrift');
+    var source = fs.readFileSync(filename, 'ascii');
+    spec = new Spec({source: source});
+    assert.pass('spec parses');
+    assert.end();
+});
+
+test('can get type result from spec', function t(assert) {
+    var res = spec.getTypeResult('Struct');
+    if (res.err) return assert.end(res.err);
+    assert.ok(res.value, 'got struct');
+    assert.end();
+});
+
+test('can get type from spec', function t(assert) {
+    var Struct = spec.getTypeResult('Struct');
+    assert.ok(Struct, 'got struct');
+    assert.end();
+});
+
+test('can get type error result from spec', function t(assert) {
+    var res = spec.getTypeResult('Bogus');
+    assert.ok(res.err, 'got error');
+    if (!res.err) return assert.end();
+    assert.equal(res.err.message, 'type Bogus not found');
+    assert.end();
+});
+
+test('can get type error from spec', function t(assert) {
+    try {
+        spec.getType('Bogus');
+        assert.fail('error expected');
+    } catch (err) {
+        assert.equal(err.message, 'type Bogus not found');
+    }
+    assert.end();
+});
+
+test('reference error in spec', function t(assert) {
+    var filename = path.join(__dirname, 'spec-reference-error.thrift');
+    var source = fs.readFileSync(filename, 'ascii');
+    try {
+        spec = new Spec({source: source});
+        assert.fail('spec should not parse');
+    } catch (err) {
+        assert.equal(err.message, 'cannot resolve reference to Struct at 3:19');
+    }
+    assert.end();
+});
+
+test('duplicate reference in spec', function t(assert) {
+    var filename = path.join(__dirname, 'spec-duplicate-error.thrift');
+    var source = fs.readFileSync(filename, 'ascii');
+    try {
+        spec = new Spec({source: source});
+        assert.fail('spec should not parse');
+    } catch (err) {
+        assert.equal(err.message, 'duplicate reference to Service at 4:9');
+    }
+    assert.end();
+});

--- a/test/spec.thrift
+++ b/test/spec.thrift
@@ -1,0 +1,7 @@
+
+struct Struct {
+}
+
+service Service {
+    Struct foo(0: Struct bar)
+}

--- a/test/struct.js
+++ b/test/struct.js
@@ -39,11 +39,11 @@ var mockSpec = {
 };
 
 healthSpec.compile({
-    name: 'Health',
+    id: {name: 'Health'},
     fields: [
         {
-            id: 0,
-            name: 'ok',
+            fieldId: 0,
+            id: {name: 'ok'},
             valueType: {
                 type: 'BaseType',
                 baseType: 'boolean'
@@ -235,11 +235,11 @@ test('every field must be marked in strict mode', function t(assert) {
     var spec = new StructSpec();
     try {
         spec.compile({
-            name: 'Health',
+            id: {name: 'Health'},
             fields: [
                 {
-                    id: 0,
-                    name: 'ok',
+                    fieldId: 0,
+                    id: {name: 'ok'},
                     valueType: {
                         type: 'BaseType',
                         baseType: 'boolean'
@@ -261,12 +261,12 @@ test('every argument must be marked required in strict mode', function t(assert)
     var spec = new StructSpec();
     try {
         spec.compile({
-            name: 'function_args',
+            id: {name: 'function_args'},
             isArgument: true,
             fields: [
                 {
-                    id: 0,
-                    name: 'namedParam',
+                    fieldId: 0,
+                    id: {name: 'namedParam'},
                     valueType: {
                         type: 'BaseType',
                         baseType: 'boolean'
@@ -287,12 +287,12 @@ test('every argument must be marked required in strict mode', function t(assert)
 test('structs and fields must be possible to rename with a js.name annotation', function t(assert) {
     var spec = new StructSpec({strict: false});
     spec.compile({
-        name: 'given',
+        id: {name: 'given'},
         annotations: {'js.name': 'alt'},
         fields: [
             {
-                id: 0,
-                name: 'given',
+                fieldId: 0,
+                id: {name: 'given'},
                 annotations: {'js.name': 'alt'},
                 valueType: {
                     type: 'BaseType',
@@ -334,12 +334,12 @@ test('arguments must not be marked optional', function t(assert) {
     var argStruct = new StructSpec({strict: false});
     try {
         argStruct.compile({
-            name: 'foo_args',
+            id: {name: 'foo_args'},
             isArgument: true,
             fields: [
                 {
-                    id: 0,
-                    name: 'name',
+                    fieldId: 0,
+                    id: {name: 'name'},
                     valueType: {
                         type: 'BaseType',
                         baseType: 'i64'
@@ -360,11 +360,11 @@ test('arguments must not be marked optional', function t(assert) {
 test('skips optional elided arguments', function t(assert) {
     var spec = new StructSpec();
     spec.compile({
-        name: 'Health',
+        id: {name: 'Health'},
         fields: [
             {
-                id: 0,
-                name: 'ok',
+                fieldId: 0,
+                id: {name: 'ok'},
                 valueType: {
                     type: 'BaseType',
                     baseType: 'boolean'
@@ -393,11 +393,11 @@ test('skips optional elided arguments', function t(assert) {
 test('skips optional elided struct (all fields optional)', function t(assert) {
     var spec = new StructSpec();
     spec.compile({
-        name: 'Health',
+        id: {name: 'Health'},
         fields: [
             {
-                id: 0,
-                name: 'ok',
+                fieldId: 0,
+                id: {name: 'ok'},
                 valueType: {
                     type: 'BaseType',
                     baseType: 'boolean'

--- a/test/struct.thrift
+++ b/test/struct.thrift
@@ -1,0 +1,3 @@
+struct Health {
+  0: optional bool ok = 1 (js.name = 'isOk')
+} (js.name = '$Health')

--- a/thrift-idl.pegjs
+++ b/thrift-idl.pegjs
@@ -6,20 +6,22 @@
     }
     Program.prototype.type = 'Program';
 
-    function Identifier(name) {
+    function Identifier(name, line, column) {
         this.name = name;
+        this.line = line;
+        this.column = column;
     }
     Identifier.prototype.type = 'Identifier';
 
-    function Namespace(name, scope) {
-        this.name = name;
+    function Namespace(id, scope) {
+        this.id = id;
         this.scope = scope;
     }
     Namespace.prototype.type = 'Namespace';
 
-    function Typedef(type, name, annotations) {
+    function Typedef(type, id, annotations) {
         this.typedefType = type;
-        this.name = name;
+        this.id = id;
         this.annotations = annotations;
     }
     Typedef.prototype.type = 'Typedef';
@@ -30,80 +32,75 @@
     }
     BaseType.prototype.type = 'BaseType';
 
-    function Enum(name, definitions, annotations) {
-        this.name = name;
+    function Enum(id, definitions, annotations) {
+        this.id = id;
         this.enumDefinitions = definitions;
         this.annotations = annotations;
     }
     Enum.prototype.type = 'Enum';
 
-    function EnumDefinition(name, value, annotations) {
-        this.name = name;
+    function EnumDefinition(id, value, annotations) {
+        this.id = id;
         this.value = value;
         this.annotations = annotations;
     }
     EnumDefinition.prototype.type = 'EnumDefinition';
 
-    function Senum(name, definitions, annotations) {
-        this.name = name;
+    function Senum(id, definitions, annotations) {
+        this.id = id;
         this.senumDefinitions = definitions;
         this.annotations = annotations;
     }
     Senum.prototype.type = 'Senum';
 
-    function Const(name, fieldType, value) {
-        this.name = name;
+    function Const(id, fieldType, value) {
+        this.id = id;
         this.fieldType = fieldType;
         this.value = value;
     }
     Const.prototype.type = 'Const';
 
-    function Struct(name, fields, annotations) {
-        this.name = name;
+    function Struct(id, fields, annotations) {
+        this.id = id;
         this.fields = fields;
         this.annotations = annotations;
         this.isArgument = false;
     }
     Struct.prototype.type = 'Struct';
 
-    function Union(name, fields) {
-        this.name = name;
+    function Union(id, fields) {
+        this.id = id;
         this.fields = fields;
     }
     Union.prototype.type = 'Union';
 
-    function Exception(name, fields, annotations) {
-        this.name = name;
+    function Exception(id, fields, annotations) {
+        this.id = id;
         this.fields = fields;
         this.annotations = annotations;
     }
     Exception.prototype.type = 'Exception';
 
-    function Service(name, functions, annotations) {
-        this.name = name;
+    function Service(id, functions, annotations) {
+        this.id = id;
         this.functions = functions;
         this.annotations = annotations;
     }
     Service.prototype.type = 'Service';
 
-    function FunctionDescription(name, fields, ft, _throws, annotations) {
-        this.name = name;
-        this.functionType = ft;
+    function FunctionDefinition(id, fields, ft, _throws, annotations) {
+        this.id = id;
+        this.returns = ft;
         this.fields = fields;
         this.fields.isArgument = true;
         this.throws = _throws;
         this.annotations = annotations;
     }
-    FunctionDescription.prototype.type = 'function';
+    FunctionDefinition.prototype.type = 'function';
 
-    function Throws(fields) {
-        this.fields = fields;
-    }
-    Throws.prototype.type = 'throws';
-
-    function Field(name, ft, id, req, fv, annotations) {
+    function Field(id, ft, fieldId, req, fv, annotations) {
         this.id = id;
-        this.name = name;
+        this.fieldId = fieldId;
         this.valueType = ft;
         this.required = req === 'required';
         this.optional = req === 'optional';
@@ -155,17 +152,17 @@ Header
   = Include
   / CppInclude
   / Namespace
-  / 'cpp_namespace' IdentifierName
-  / 'php_namespace' IdentifierName
-  / 'py_module' IdentifierName
-  / 'perl_package' IdentifierName
-  / 'ruby_namespace' IdentifierName
-  / 'smalltalk_category' STIdentifierName
-  / 'smalltalk_prefix' IdentifierName
-  / 'java_package' IdentifierName
-  / 'cocoa_package' IdentifierName
+  / 'cpp_namespace' Identifier
+  / 'php_namespace' Identifier
+  / 'py_module' Identifier
+  / 'perl_package' Identifier
+  / 'ruby_namespace' Identifier
+  / 'smalltalk_category' STIdentifier
+  / 'smalltalk_prefix' Identifier
+  / 'java_package' Identifier
+  / 'cocoa_package' Identifier
   / 'xsd_namespace' Literal
-  / 'csharp_namespace' IdentifierName
+  / 'csharp_namespace' Identifier
 
 Include
   = IncludeToken Literal
@@ -174,13 +171,13 @@ CppInclude
   = CppIncludeToken Literal
 
 Namespace
-  = NamespaceToken scope:NamespaceScope __ name:IdentifierName { return new Namespace(name, scope); }
-  / NamespaceToken 'smalltalk.category' __ STIdentifierName
-  / NamespaceToken 'smalltalk.prefix' __ IdentifierName
+  = NamespaceToken scope:NamespaceScope __ id:Identifier { return new Namespace(id, scope); }
+  / NamespaceToken 'smalltalk.category' __ STIdentifier
+  / NamespaceToken 'smalltalk.prefix' __ Identifier
   / 'php_namespace' __ Literal
   / 'xsd_namespace' __ Literal
-  / NamespaceToken scope:'*' __ IdentifierName { return; }
-  / NamespaceToken scope:IdentifierName name:IdentifierName { return; }
+  / NamespaceToken scope:'*' __ Identifier { return; }
+  / NamespaceToken scope:Identifier id:Identifier { return; }
 
 NamespaceScope
   = 'cpp'
@@ -211,8 +208,8 @@ Definition
   / Service
 
 Typedef
-  = TypedefToken __ dt:DefinitionType name:IdentifierName ta:TypeAnnotations? ListSeparator? {
-    return new Typedef(dt, name, ta);
+  = TypedefToken __ dt:DefinitionType id:Identifier ta:TypeAnnotations? ListSeparator? {
+    return new Typedef(dt, id, ta);
   }
 
 DefinitionType
@@ -226,26 +223,26 @@ ListSeparator 'list separator'
   = CommaOrSemicolon
 
 Enum
-  = EnumToken __ name:IdentifierName __ '{' __ ed:EnumDefinition* __ '}' __ ta:TypeAnnotations? {
-    return new Enum(name, ed, ta);
+  = EnumToken __ id:Identifier __ '{' __ ed:EnumDefinition* __ '}' __ ta:TypeAnnotations? {
+    return new Enum(id, ed, ta);
   }
 
 EnumDefinition
-  = name:IdentifierName value:('=' __ v:IntConstant { return v.value })? __ ta:TypeAnnotations? ListSeparator? __ {
-    return new EnumDefinition(name, value, ta);
+  = id:Identifier value:('=' __ v:IntConstant { return v.value })? __ ta:TypeAnnotations? ListSeparator? __ {
+    return new EnumDefinition(id, value, ta);
   }
 
 Senum
-  = SenumToken name:IdentifierName '{' __ ss:SenumDefinition* '}' __ ta:TypeAnnotations? {
-    return new Senum(name, ss, ta);
+  = SenumToken id:Identifier '{' __ ss:SenumDefinition* '}' __ ta:TypeAnnotations? {
+    return new Senum(id, ss, ta);
   }
 
 SenumDefinition
   = s:Literal ListSeparator? { return s; }
 
 Const
-  = ConstToken ft:FieldType name:IdentifierName '=' __ cv:ConstValue ListSeparator? __ {
-    return new Const(name, ft, cv);
+  = ConstToken ft:FieldType id:Identifier '=' __ cv:ConstValue ListSeparator? __ {
+    return new Const(id, ft, cv);
   }
 
 ConstValue
@@ -267,13 +264,13 @@ ConstValuePair
   = k:ConstValue __ ':' __ v:ConstValue __ ListSeparator?
 
 Struct
-  = 'struct' __ name:IdentifierName xsdAll? __ '{' __ fs:Field* __ '}' __ ta:TypeAnnotations? {
-    return new Struct(name, fs, ta);
+  = 'struct' __ id:Identifier xsdAll? __ '{' __ fs:Field* __ '}' __ ta:TypeAnnotations? {
+    return new Struct(id, fs, ta);
   }
 
 Union
-  = UnionToken name:IdentifierName xsdAll? __ '{' __ fs:Field* __ '}' __ {
-    return new Union(name, fs);
+  = UnionToken id:Identifier xsdAll? __ '{' __ fs:Field* __ '}' __ {
+    return new Union(id, fs);
   }
 
 xsdAll
@@ -289,21 +286,21 @@ xsdAttributes
   = 'xsd_attributes' __ '{' __ Field* __ '}' __
 
 Exception
-  = 'exception' __ name:IdentifierName '{' __ fs:Field* __ '}' __ ta:TypeAnnotations? __ {
-    return new Exception(name, fs, ta);
+  = 'exception' __ id:Identifier '{' __ fs:Field* __ '}' __ ta:TypeAnnotations? __ {
+    return new Exception(id, fs, ta);
   }
 
 Service
-  = 'service' __ name:IdentifierName extends? '{' __ fns:function* __ '}' __ ta:TypeAnnotations? {
-    return new Service(name, fns, ta);
+  = 'service' __ id:Identifier extends? '{' __ fns:function* __ '}' __ ta:TypeAnnotations? {
+    return new Service(id, fns, ta);
   }
 
 extends
   = 'extends' __ IdentifierName
 
 function
-  = __ oneway? ft:FunctionType name:IdentifierName '(' __ fs:Field* __ ')' __ ts:throwz? ta:TypeAnnotations? ListSeparator? _ {
-    return new FunctionDescription(name, fs, ft, ts, ta);
+  = __ oneway? ft:FunctionType id:Identifier '(' __ fs:Field* __ ')' __ ts:throwz? ta:TypeAnnotations? ListSeparator? _ {
+    return new FunctionDefinition(id, fs, ft, ts, ta);
   }
 
 oneway
@@ -311,13 +308,13 @@ oneway
 
 throwz
   = 'throws' __ '(' __ fs:Field* __ ')' __ {
-    return new Throws(fs);
+    return fs;
   }
 
 Field
-  = _ id:FieldIdentifier? req:FieldRequiredness? ft:FieldType rec:Recursive? name:IdentifierName fv:FieldValue?
+  = _ id:FieldIdentifier? req:FieldRequiredness? ft:FieldType rec:Recursive? id:IdentifierName fv:FieldValue?
     XsdFieldOptions? ta:TypeAnnotations? ListSeparator? {
-      return new Field(name, ft, id, req, fv, ta);
+      return new Field(id, ft, id, req, fv, ta);
     }
 
 Recursive
@@ -417,7 +414,7 @@ word
   = w:[a-zA-Z0-9_\.]+
 
 Identifier
-  = name:IdentifierName __ { return new Identifier(name); }
+  = name:IdentifierName __ { return new Identifier(name, line(), column()); }
 
 IdentifierName 'identifier'
   = !ReservedWord first:IdentifierStart rest:IdentifierPart* __ {
@@ -457,6 +454,9 @@ UnicodeConnectorPunctuation
 
 Letter
   = [a-zA-Z]
+
+STIdentifier
+  = name:STIdentifierName { return new Identifier(name, line(), column()); }
 
 STIdentifierName
   = !container_type_tokens word /* ('a'..'z' | 'A'..'Z' | '-')


### PR DESCRIPTION
With only Struct and base types so far, this is the skeleton that orchestrates the conversion of a Thrift IDL AST into a structure with Specs for all the services and structs.

Note the adjustment to the AST so identifiers can carry line and column numbers, to provide insightful reference errors (per @abhinav).

This is intended to be interface compatible with Thriftify so we can just drop it in.