### PR TITLE
Fix field name syntax tree

### DIFF
--- a/service.js
+++ b/service.js
@@ -47,7 +47,7 @@ FunctionSpec.prototype.compile = function process(def, spec) {
     var resultFields = def.throws || [];
     resultFields.unshift({ // TODO use Field constructor from pegjs...somehow
         id: {value: 0},
-        name: {name: 'success'},
+        name: 'success',
         valueType: def.returns,
         required: true,
         optional: false,

--- a/struct.js
+++ b/struct.js
@@ -37,12 +37,12 @@ function FieldSpec(def, struct) {
     var self = this;
     assert(def.isResult || def.id.value > 0,
         'field identifier must be greater than 0' +
-        ' for ' + JSON.stringify(def.name.name) +
+        ' for ' + JSON.stringify(def.name) +
         ' on ' + JSON.stringify(struct.name) +
         ' at ' + def.id.line + ':' + def.id.column
     );
     self.id = def.id.value;
-    self.name = def.name.name;
+    self.name = def.name;
     self.required = def.required;
     self.optional = def.optional;
     self.annotations = def.annotations;
@@ -89,11 +89,11 @@ StructSpec.prototype.compile = function compile(def) {
         if (self.strict) {
             assert(field.required || field.optional,
                 'every field must be marked optional or required on ' + self.name +
-                    ' including ' + field.name + ' in strict mode'
+                    ' including "' + field.name + '" in strict mode'
             );
             if (self.isArgument && !field.required) {
                 assert.ok(false, 'every field must be marked required on ' + self.name +
-                    ' including ' + field.name + ' in strict mode');
+                    ' including "' + field.name + '" in strict mode');
             }
         }
         if (self.isArgument && field.optional) {

--- a/test/struct.js
+++ b/test/struct.js
@@ -43,7 +43,7 @@ healthSpec.compile({
     fields: [
         {
             id: {value: 1},
-            name: {name: 'ok'},
+            name: 'ok',
             valueType: {
                 type: 'BaseType',
                 baseType: 'boolean'
@@ -239,7 +239,7 @@ test('every field must be marked in strict mode', function t(assert) {
             fields: [
                 {
                     id: {value: 1},
-                    name: {name: 'ok'},
+                    name: 'ok',
                     valueType: {
                         type: 'BaseType',
                         baseType: 'boolean'
@@ -252,7 +252,7 @@ test('every field must be marked in strict mode', function t(assert) {
         assert.fail('should throw');
     } catch (err) {
         assert.equal(err.message, 'every field must be marked optional or ' +
-            'required on Health including ok in strict mode');
+            'required on Health including "ok" in strict mode');
     }
     assert.end();
 });
@@ -266,7 +266,7 @@ test('every argument must be marked required in strict mode', function t(assert)
             fields: [
                 {
                     id: {value: 1},
-                    name: {name: 'namedParam'},
+                    name: 'namedParam',
                     valueType: {
                         type: 'BaseType',
                         baseType: 'boolean'
@@ -279,7 +279,7 @@ test('every argument must be marked required in strict mode', function t(assert)
         assert.fail('should throw');
     } catch (err) {
         assert.equal(err.message, 'every field must be marked ' +
-            'required on function_args including namedParam in strict mode');
+            'required on function_args including "namedParam" in strict mode');
     }
     assert.end();
 });
@@ -292,7 +292,7 @@ test('structs and fields must be possible to rename with a js.name annotation', 
         fields: [
             {
                 id: {value: 1},
-                name: {name: 'given'},
+                name: 'given',
                 annotations: {'js.name': 'alt'},
                 valueType: {
                     type: 'BaseType',
@@ -339,7 +339,7 @@ test('arguments must not be marked optional', function t(assert) {
             fields: [
                 {
                     id: {value: 1},
-                    name: {name: 'name'},
+                    name: 'name',
                     valueType: {
                         type: 'BaseType',
                         baseType: 'i64'
@@ -364,7 +364,7 @@ test('skips optional elided arguments', function t(assert) {
         fields: [
             {
                 id: {value: 1},
-                name: {name: 'ok'},
+                name: 'ok',
                 valueType: {
                     type: 'BaseType',
                     baseType: 'boolean'
@@ -397,7 +397,7 @@ test('skips optional elided struct (all fields optional)', function t(assert) {
         fields: [
             {
                 id: {value: 1},
-                name: {name: 'ok'},
+                name: 'ok',
                 valueType: {
                     type: 'BaseType',
                     baseType: 'boolean'
@@ -430,7 +430,7 @@ test('enforces ordinal identifiers', function t(assert) {
             fields: [
                 {
                     id: {value: 0, line: 1, column: 4},
-                    name: {name: 'ok'},
+                    name: 'ok',
                     valueType: {
                         type: 'BaseType',
                         baseType: 'boolean'


### PR DESCRIPTION
There was an extraneous layer to identifier name AST nodes, in wasted anticipation of needing to grab the location of a field name for error reporting.