### PR TITLE
Remove type annotations from exception

### DIFF
--- a/test/exception.js
+++ b/test/exception.js
@@ -29,14 +29,56 @@ var Thrift = require('../thrift').Thrift;
 var source = fs.readFileSync(path.join(__dirname, 'exception.thrift'), 'ascii');
 var thrift = new Thrift({source: source});
 
+var err = new Error('Bogus name: Voldemort');
+err.name = 'ThriftException';
+err.bogusName = 'Voldemort';
+
 test('Exception RW', testRW.cases(thrift.BogusNameError.rw, [
 
-    [thrift.BogusNameError({bogusName: 'Voldemort'}), [
+    [err, [
         0x0b,                         // typeid:1 -- 11, STRING
         0x00, 0x01,                   // id:2     -- 1, bogusName
         0x00, 0x00, 0x00, 0x09,       // length:4 -- 9
         0x56, 0x6f, 0x6c, 0x64, 0x65, //          -- 'Voldemort'
         0x6d, 0x6f, 0x72, 0x74,       //
+        0x0b,                         // typeid:1 -- 11, STRING
+        0x00, 0x02,                   // id:2     -- 2, message
+        0x00, 0x00, 0x00, 0x15,       // lenght:4 -- 21
+        0x42, 0x6f, 0x67, 0x75, 0x73,
+        0x20, 0x6e, 0x61, 0x6d, 0x65,
+        0x3a, 0x20, 0x56, 0x6f, 0x6c,
+        0x64, 0x65, 0x6d, 0x6f, 0x72,
+        0x74,
+        0x00                          // typeid:1 -- 0, STOP
+    ]]
+
+]));
+
+var err2 = new Error('Bogus name: Voldemort');
+err2.name = 'ThriftException';
+Object.defineProperty(err2, 'type', {
+    value: 'Voldemort',
+    configurable: true,
+    enumerable: true,
+    writable: true
+});
+
+test('Exception RW with type', testRW.cases(thrift.BogusWithType.rw, [
+
+    [err2, [
+        0x0b,                         // typeid:1 -- 11, STRING
+        0x00, 0x01,                   // id:2     -- 1, type
+        0x00, 0x00, 0x00, 0x09,       // length:4 -- 9
+        0x56, 0x6f, 0x6c, 0x64, 0x65, //          -- 'Voldemort'
+        0x6d, 0x6f, 0x72, 0x74,       //
+        0x0b,                         // typeid:1 -- 11, STRING
+        0x00, 0x02,                   // id:2     -- 2, message
+        0x00, 0x00, 0x00, 0x15,       // lenght:4 -- 21
+        0x42, 0x6f, 0x67, 0x75, 0x73,
+        0x20, 0x6e, 0x61, 0x6d, 0x65,
+        0x3a, 0x20, 0x56, 0x6f, 0x6c,
+        0x64, 0x65, 0x6d, 0x6f, 0x72,
+        0x74,
         0x00                          // typeid:1 -- 0, STOP
     ]]
 

--- a/test/exception.thrift
+++ b/test/exception.thrift
@@ -1,6 +1,9 @@
 exception BogusNameError {
     1: required string bogusName
-} (
-    type = 'bogus-name-error'
-    message = 'Bogus name: {bogusName}'
-)
+    2: required string message
+}
+
+exception BogusWithType {
+    1: required string type
+    2: required string message
+}


### PR DESCRIPTION
This removes the expectation on the Thrift IDL parser
that all exceptions have type & message annotations.

These annotations do not really make sense in other
languages so it would make it difficult to parse
thrift IDLs from other languages.

r: @kriskowal @abg