### PR TITLE
Fix the field skipper and tests

### DIFF
--- a/skip.js
+++ b/skip.js
@@ -234,3 +234,4 @@ function skipList(buffer, offset) {
 }
 
 module.exports.skipField = skipField;
+module.exports.skipType = skipType;

--- a/struct.js
+++ b/struct.js
@@ -28,7 +28,7 @@ var bufrw = require('bufrw');
 var TYPE = require('./TYPE');
 var NAMES = require('./names');
 var errors = require('./errors');
-var skipField = require('./skip').skipField;
+var skipType = require('./skip').skipType;
 
 var LengthResult = bufrw.LengthResult;
 var WriteResult = bufrw.WriteResult;
@@ -372,7 +372,7 @@ StructRW.prototype.readFrom = function readFrom(buffer, offset) {
 
         // skip unrecognized fields from THE FUTURE
         if (!self.spec.fieldsById[id]) {
-            result = skipField(buffer, offset);
+            result = skipType(buffer, offset, typeid);
             // istanbul ignore if
             if (result.err) {
                 return result;

--- a/test/struct-skip.js
+++ b/test/struct-skip.js
@@ -35,7 +35,8 @@ test('skip void', function t(assert) {
     var result = Health.rw.readFrom(new Buffer([
         0x02,                     // type:1   -- 2 -- BOOL
         0x00, 0x02,               // id:2     -- 2 -- WHAT EVEN IS!?
-        0x01,                     // typeid:1 -- 1 -- VOID
+        0x00,                     // bool:1
+
         0x00                      // typeid:1 -- 0 -- STOP
     ]), 0);
     if (result.err) {
@@ -47,9 +48,8 @@ test('skip void', function t(assert) {
 
 test('string', function t(assert) {
     var result = Health.rw.readFrom(new Buffer([
-        0x02,                     // type:1   -- 2  -- BOOL
-        0x00, 0x02,               // id:2     -- 2  -- WHAT EVEN IS!?
         11,                       // typeid:1 -- 11 -- STRING
+        0x00, 0x02,               // id:2     -- 2  -- WHAT EVEN IS!?
         0x00, 0x00, 0x00, 0x02,   // len~4
         0x20, 0x20,               // '  '
         0x00                      // typeid:1 -- 0  -- STOP
@@ -63,16 +63,13 @@ test('string', function t(assert) {
 
 test('struct', function t(assert) {
     var result = Health.rw.readFrom(new Buffer([
-        0x02,                     // type:1   -- 2  -- BOOL
-        0x00, 0x02,               // id:2     -- 2  -- WHAT EVEN IS!?
         12,                       // typeid:1 -- 12 -- STRUCT
-        0x01,                     // typeid:1 -- 1  -- VOID
-        0x01,                     // typeid:1 -- 1  -- VOID
-        11,                       // typeid:1 -- 11 -- STRING
-        0x00, 0x00, 0x00, 0x02,   // len~4
-        0x20, 0x20,               // '  '
-        0x01,                     // typeid:1 -- 1  -- VOID
-        0x00,                     // typeid:1 -- 0  -- STOP
+        0x00, 0x02,               // id:2     -- 2  -- ?
+        11,                       //   typeid:1 -- 11 -- STRING
+        0x00, 0x01,               //   fieldid:2 -- 1 -- ?
+        0x00, 0x00, 0x00, 0x02,   //   len~4
+        0x20, 0x20,               //   '  '
+        0x00,                     //   typeid:1 -- 0  -- STOP
         0x00                      // typeid:1 -- 0  -- STOP
     ]), 0);
     if (result.err) {
@@ -84,9 +81,8 @@ test('struct', function t(assert) {
 
 test('map', function t(assert) {
     var result = Health.rw.readFrom(new Buffer([
-        0x02,                     // type:1           -- 2 BOOL
-        0x00, 0x02,               // id:2             -- 2 UNKNOWN
         0x0d,                   // typeid:1           -- 13, map
+        0x00, 0x02,             // id:2               -- 2 UNKNOWN
 
         // Thus begins a large map
         0x0b,                   // key_type:1         -- string    @ 4

--- a/test/struct.js
+++ b/test/struct.js
@@ -94,10 +94,12 @@ test('struct skips unknown void', function t(assert) {
     var res = Health.rw.readFrom(new Buffer([
         0x02,                     // type:1   -- 2 -- BOOL
         0x00, 0x02,               // id:2     -- 2 -- WHAT EVEN IS!?
-        0x01,                     // typeid:1 -- 1 -- VOID
+        0x00,                     // bool:1
+
         0x02,                     // type:1   -- 2 -- BOOL
         0x00, 0x01,               // id:2     -- 1 -- ok
         0x01,                     // ok:1     -- 1 -- true
+
         0x00                      // typeid:1 -- 0 -- STOP
     ]), 0);
     if (res.err) {
@@ -128,11 +130,12 @@ test('struct skips unknown string', function t(assert) {
         0x02,                     // type:1   -- 2 -- BOOL
         0x00, 0x01,               // id:2     -- 1 -- ok
         0x01,                     // ok:1     -- 1 -- true
-        0x02,                     // type:1   -- 2  -- BOOL
-        0x00, 0x02,               // id:2     -- 2  -- WHAT EVEN IS!?
+
         11,                       // typeid:1 -- 11 -- STRING
+        0x00, 0x02,               // id:2     -- 2  -- WHAT EVEN IS!?
         0x00, 0x00, 0x00, 0x02,   // len~4
         0x20, 0x20,               // '  '
+
         0x00                      // typeid:1 -- 0  -- STOP
     ]), 0);
     if (res.err) {
@@ -147,9 +150,10 @@ test('struct skips unknown struct', function t(assert) {
         0x02,                     // type:1   -- 2 -- BOOL
         0x00, 0x01,               // id:2     -- 1 -- ok
         0x01,                     // ok:1     -- 1 -- true
-        0x02,                     // type:1   -- 2  -- BOOL
-        0x00, 0x02,               // id:2     -- 2  -- WHAT EVEN IS!?
+
         0x0c,                     // typeid:1 -- 12 -- STRUCT
+        0x00, 0x02,               // id:2     -- 2  -- WHAT EVEN IS!?
+
         0x01,                     // typeid:1 -- 1  -- VOID
         0x01,                     // typeid:1 -- 1  -- VOID
         0x0b,                     // typeid:1 -- 11 -- STRING
@@ -157,6 +161,7 @@ test('struct skips unknown struct', function t(assert) {
         0x20, 0x20,               // '  '
         0x01,                     // typeid:1 -- 1  -- VOID
         0x00,                     // typeid:1 -- 0  -- STOP
+
         0x00                      // typeid:1 -- 0  -- STOP
     ]), 0);
     if (res.err) {
@@ -172,9 +177,8 @@ test('struct skips uknown map', function t(assert) {
         0x00, 0x01,               // id:2     -- 1 ok
         0x01,                     // ok:1     -- 1 true
 
-        0x02,                     // type:1   -- 2 BOOL
-        0x00, 0x02,               // id:2     -- 2 UNKNOWN
         0x0d,                     // typeid:1 -- 13, map
+        0x00, 0x02,               // id:2     -- 2 UNKNOWN
 
         // Thus begins a large map
         0x0b,                   // key_type:1         -- string    @ 4
@@ -231,9 +235,8 @@ test('struct skips unknown list', function t(assert) {
         0x00, 0x01,               // id:2     -- 1 ok
         0x00,                     // ok:1     -- 0 false
 
-        0x02,                     // type:1      -- 2 BOOL
-        0x00, 0x02,               // id:2        -- 2 UNKNOWN
         0x0f,                     // typeid:1    -- 15, list
+        0x00, 0x02,               // id:2        -- 2 UNKNOWN
 
         // Thus begins a list
         0x0c,                   // el_type:1     -- struct


### PR DESCRIPTION
The tests and the implementation were incorrect. The skipper needed to use skipType instead of skipField since the typeid was already read off the wire. skipField continues to exist but only as a vestige of the skip tests. All use in the context of a struct uses skipType.