### PR TITLE
Release refs after compiling the IDLs

### DIFF
--- a/thrift.js
+++ b/thrift.js
@@ -365,17 +365,13 @@ Thrift.prototype.link = function link() {
     // As part of the linking process, we also release aliased
     // refs to idls, asts, etc.
     if (this.releaseSources) {
-        this.releaseResources();
+        this.idls = null;
+        this.asts = null;
+        this.memo = null;
     }
 
     return this;
 };
-
-Thrift.prototype.releaseResources = function release() {
-    this.idls = null;
-    this.asts = null;
-    this.memo = null;
-}
 
 Thrift.prototype.resolve = function resolve(def) {
     // istanbul ignore else

--- a/thrift.js
+++ b/thrift.js
@@ -114,7 +114,7 @@ function Thrift(options) {
     this.surface = this;
 
     this.linked = false;
-    this.releaseSources = options.releaseSources;
+    this.releaseSources = options.releaseSources || false;
     this.allowIncludeAlias = options.allowIncludeAlias || false;
     this.allowOptionalArguments = options.allowOptionalArguments || false;
 
@@ -285,7 +285,8 @@ Thrift.prototype.compileInclude = function compileInclude(def) {
                 allowIncludeAlias: true,
                 allowOptionalArguments: this.allowOptionalArguments,
                 noLink: true,
-                releaseSources: this.releaseSources,defaultAsUndefined: this.defaultAsUndefined
+                releaseSources: this.releaseSources,
+                defaultAsUndefined: this.defaultAsUndefined
             });
         }
 

--- a/thrift.js
+++ b/thrift.js
@@ -114,6 +114,7 @@ function Thrift(options) {
     this.surface = this;
 
     this.linked = false;
+    this.releaseSources = options.releaseSources;
     this.allowIncludeAlias = options.allowIncludeAlias || false;
     this.allowOptionalArguments = options.allowOptionalArguments || false;
 
@@ -361,8 +362,10 @@ Thrift.prototype.link = function link() {
     this.exception.link(this);
 
     // As part of the linking process, we also release aliased
-    // refs to idls, asts
-    this.releaseResources();
+    // refs to idls, asts, etc.
+    if (this.releaseSources) {
+        this.releaseResources();
+    }
 
     return this;
 };

--- a/thrift.js
+++ b/thrift.js
@@ -285,7 +285,7 @@ Thrift.prototype.compileInclude = function compileInclude(def) {
                 allowIncludeAlias: true,
                 allowOptionalArguments: this.allowOptionalArguments,
                 noLink: true,
-                defaultAsUndefined: this.defaultAsUndefined
+                releaseSources: this.releaseSources,defaultAsUndefined: this.defaultAsUndefined
             });
         }
 

--- a/thrift.js
+++ b/thrift.js
@@ -360,8 +360,18 @@ Thrift.prototype.link = function link() {
 
     this.exception.link(this);
 
+    // As part of the linking process, we also release aliased
+    // refs to idls, asts
+    this.releaseResources();
+
     return this;
 };
+
+Thrift.prototype.releaseResources = function release() {
+    this.idls = null;
+    this.asts = null;
+    this.memo = null;
+}
 
 Thrift.prototype.resolve = function resolve(def) {
     // istanbul ignore else


### PR DESCRIPTION
Release refs after compiling the IDLs to make sure that no unnecessary source files are pinned in memory.

This is a forced optimization as we see more and more memory pressure in services running the ThriftRW.

More details could be found in T6741709.